### PR TITLE
Fix: CookieUtil.SECURE 을 true로 변경 및 로그아웃 API 추가.

### DIFF
--- a/src/main/java/com/example/soso/global/config/CookieUtil.java
+++ b/src/main/java/com/example/soso/global/config/CookieUtil.java
@@ -8,7 +8,7 @@ import java.time.Duration;
 public class CookieUtil {
 
     private static final String SAME_SITE = "None";
-    private static final boolean SECURE = false;
+    private static final boolean SECURE = true;  // HTTPS 필수 (SameSite=None 요구사항)
     private static final boolean HTTP_ONLY = true;
     private static final String PATH = "/";
 
@@ -19,6 +19,17 @@ public class CookieUtil {
                 .secure(SECURE)
                 .path(PATH)
                 .maxAge(Duration.ofMillis(maxAgeMs))
+                .sameSite(SAME_SITE)
+                .build();
+        response.setHeader("Set-Cookie", cookie.toString());
+    }
+
+    public static void deleteRefreshTokenCookie(HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", "")
+                .httpOnly(HTTP_ONLY)
+                .secure(SECURE)
+                .path(PATH)
+                .maxAge(0)  // 즉시 만료
                 .sameSite(SAME_SITE)
                 .build();
         response.setHeader("Set-Cookie", cookie.toString());

--- a/src/main/java/com/example/soso/users/controller/AuthController.java
+++ b/src/main/java/com/example/soso/users/controller/AuthController.java
@@ -43,4 +43,25 @@ public class AuthController {
         JwtTokenDto jwtToken = authService.refreshAccessToken(refreshToken, response);
         return ResponseEntity.ok(jwtToken);
     }
+
+    @Operation(
+            summary = "로그아웃",
+            description = "Refresh Token을 무효화하고 쿠키를 삭제합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+                    @ApiResponse(responseCode = "400", description = "Refresh Token이 없음")
+            }
+    )
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
+            @Parameter(description = "HttpOnly 쿠키에 저장된 Refresh Token")
+            @CookieValue(value = "refreshToken", required = false) String refreshToken,
+            HttpServletResponse response
+    ) {
+        if (refreshToken == null) {
+            return ResponseEntity.badRequest().build();
+        }
+        authService.logout(refreshToken, response);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/example/soso/users/service/AuthService.java
+++ b/src/main/java/com/example/soso/users/service/AuthService.java
@@ -7,4 +7,6 @@ public interface AuthService {
 
     JwtTokenDto refreshAccessToken(String refreshToken, HttpServletResponse response);
 
+    void logout(String refreshToken, HttpServletResponse response);
+
 }

--- a/src/main/java/com/example/soso/users/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/soso/users/service/AuthServiceImpl.java
@@ -48,4 +48,13 @@ public class AuthServiceImpl implements AuthService {
         return new JwtTokenDto(newAccessToken);
     }
 
+    @Override
+    public void logout(String refreshToken, HttpServletResponse response) {
+        // 1. Redis에서 Refresh Token 삭제 (즉시 무효화)
+        refreshTokenService.delete(refreshToken);
+
+        // 2. 쿠키 삭제
+        CookieUtil.deleteRefreshTokenCookie(response);
+    }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,9 @@ server:
     session:
       cookie:
         name: JSESSIONID
+        same-site: none      # 크로스 사이트 쿠키 허용 (localhost → soso.dreampaste.com)
+        secure: true         # HTTPS에서만 전송
+        http-only: true      # XSS 공격 방어 (JavaScript 접근 차단)
 
 spring:
   datasource:


### PR DESCRIPTION
##  1. CookieUtil.java:11-12 - SECURE = true
 문제점:
  - SameSite=None은 Secure=true 필수 (브라우저 정책)
  - 현재 설정은 브라우저가 쿠키를 거부함
  - HTTPS 환경에서도 작동 안 함

  영향:
  - Refresh Token 쿠키가 전달 안 됨
  - 토큰 갱신 불가능

  해결:
  private static final boolean SECURE = true;
  
  ## 2. 로그아웃 API 추가.
  - RefreshTokenRedisRepository.delete() 메서드는 있지만  엔드포인트 없음
  - 따라서 로그아웃 API를 추가했습니다.