### PR TITLE
Feat: 유저 정보 조회 API 추가

### DIFF
--- a/src/main/java/com/example/soso/kakao/controller/KakaoAuthController.java
+++ b/src/main/java/com/example/soso/kakao/controller/KakaoAuthController.java
@@ -1,10 +1,11 @@
 package com.example.soso.kakao.controller;
 
 import com.example.soso.kakao.dto.KakaoLoginRequest;
-import com.example.soso.kakao.dto.KakaoLoginResult;
+import com.example.soso.kakao.dto.KakaoLoginResponse;
 import com.example.soso.kakao.service.KakaoService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -24,21 +25,27 @@ public class KakaoAuthController {
 
     @Operation(
             summary = "카카오 로그인",
-            description = "카카오 인가 코드를 통해 사용자 로그인을 처리하고 JWT 토큰을 반환합니다.",
+            description = "카카오 인가 코드를 통해 사용자 로그인을 처리합니다. 기존 사용자는 JWT 토큰 및 사용자 정보를 반환하고, 신규 사용자는 회원가입 세션을 생성합니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "로그인 성공",
-                            content = @Content(schema = @Schema(implementation = KakaoLoginResult.class))),
+                            content = @Content(
+                                    schema = @Schema(implementation = KakaoLoginResponse.class),
+                                    examples = {
+                                            @ExampleObject(name = "기존 사용자", value = "{\"isNewUser\": false, \"accessToken\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...\", \"user\": {\"id\": \"550e8400-e29b-41d4-a716-446655440000\", \"username\": \"홍길동\", \"nickname\": \"길동이\", \"email\": \"user@example.com\"}}"),
+                                            @ExampleObject(name = "신규 사용자", value = "{\"isNewUser\": true, \"accessToken\": null, \"user\": null}")
+                                    }
+                            )),
                     @ApiResponse(responseCode = "400", description = "잘못된 요청 형식"),
                     @ApiResponse(responseCode = "500", description = "서버 오류")
             }
     )
     @PostMapping("/login")
-    public ResponseEntity<KakaoLoginResult> kakaoLogin(
+    public ResponseEntity<KakaoLoginResponse> kakaoLogin(
             @RequestBody KakaoLoginRequest request,
             HttpSession session,
             HttpServletResponse response
     ) {
-        KakaoLoginResult result = kakaoService.login(
+        KakaoLoginResponse result = kakaoService.login(
                 request.code(),
                 request.codeVerifier(),
                 request.redirectUri(),

--- a/src/main/java/com/example/soso/kakao/dto/KakaoLoginResponse.java
+++ b/src/main/java/com/example/soso/kakao/dto/KakaoLoginResponse.java
@@ -1,0 +1,20 @@
+package com.example.soso.kakao.dto;
+
+import com.example.soso.users.domain.dto.UserResponse;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "카카오 로그인 응답")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record KakaoLoginResponse(
+
+        @Schema(description = "신규 사용자 여부 (true: 회원가입 필요, false: 기존 사용자)", example = "false", requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean isNewUser,
+
+        @Schema(description = "Access Token (기존 사용자인 경우에만 제공)", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+        String accessToken,
+
+        @Schema(description = "사용자 정보 (기존 사용자인 경우에만 제공)")
+        UserResponse user
+
+) {}

--- a/src/main/java/com/example/soso/kakao/service/KakaoService.java
+++ b/src/main/java/com/example/soso/kakao/service/KakaoService.java
@@ -1,11 +1,11 @@
 package com.example.soso.kakao.service;
 
-import com.example.soso.kakao.dto.KakaoLoginResult;
+import com.example.soso.kakao.dto.KakaoLoginResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
 public interface KakaoService {
 
-   KakaoLoginResult login(String code, String codeVerifier, String redirectUri, HttpSession session, HttpServletResponse
+   KakaoLoginResponse login(String code, String codeVerifier, String redirectUri, HttpSession session, HttpServletResponse
            response);
 }

--- a/src/main/java/com/example/soso/kakao/service/KakaoServiceImpl.java
+++ b/src/main/java/com/example/soso/kakao/service/KakaoServiceImpl.java
@@ -1,6 +1,6 @@
 package com.example.soso.kakao.service;
 
-import com.example.soso.kakao.dto.KakaoLoginResult;
+import com.example.soso.kakao.dto.KakaoLoginResponse;
 import com.example.soso.kakao.dto.KakaoUserProfileDto;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
@@ -18,7 +18,7 @@ public class KakaoServiceImpl implements KakaoService {
 
 
     @Override
-    public KakaoLoginResult login(String code, String codeVerifier, String redirectUri, HttpSession session, HttpServletResponse
+    public KakaoLoginResponse login(String code, String codeVerifier, String redirectUri, HttpSession session, HttpServletResponse
             response) {
         KakaoUserProfileDto profile = kakaoOAuthService.fetchUserProfile(code, codeVerifier, redirectUri);
 
@@ -27,6 +27,6 @@ public class KakaoServiceImpl implements KakaoService {
         }
 
         signupSessionService.save(session, profile);
-        return new KakaoLoginResult(true, null); // 신규 유저: accessToken은 발급 안 함
+        return new KakaoLoginResponse(true, null, null); // 신규 유저: accessToken과 user 정보 없음
     }
 }

--- a/src/main/java/com/example/soso/kakao/service/UserLoginService.java
+++ b/src/main/java/com/example/soso/kakao/service/UserLoginService.java
@@ -6,7 +6,10 @@ import com.example.soso.global.exception.util.UserAuthException;
 import com.example.soso.global.jwt.JwtProperties;
 import com.example.soso.global.jwt.JwtProvider;
 import com.example.soso.global.redis.RefreshTokenRedisRepository;
-import com.example.soso.kakao.dto.KakaoLoginResult;
+import com.example.soso.kakao.dto.KakaoLoginResponse;
+import com.example.soso.users.domain.dto.UserMapper;
+import com.example.soso.users.domain.dto.UserResponse;
+import com.example.soso.users.domain.entity.Users;
 import com.example.soso.users.repository.UsersRepository;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -25,17 +28,18 @@ public class UserLoginService {
         return userRepository.existsByEmail(email);
     }
 
-    public KakaoLoginResult login(String email, HttpServletResponse response) {
-        String userId = userRepository.findByEmail(email)
-                .orElseThrow(() -> new UserAuthException(UserErrorCode.USER_NOT_FOUND))
-                .getId();
+    public KakaoLoginResponse login(String email, HttpServletResponse response) {
+        Users user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserAuthException(UserErrorCode.USER_NOT_FOUND));
 
-        String accessToken = jwtProvider.generateAccessToken(userId);
+        String accessToken = jwtProvider.generateAccessToken(user.getId());
         String refreshToken = jwtProvider.generateRefreshToken();
 
-        refreshTokenService.save(refreshToken, userId, jwtProperties.getRefreshTokenValidityInMs());
+        refreshTokenService.save(refreshToken, user.getId(), jwtProperties.getRefreshTokenValidityInMs());
         CookieUtil.addRefreshTokenCookie(response, refreshToken, jwtProperties.getRefreshTokenValidityInMs());
 
-        return new KakaoLoginResult(false, accessToken);
+        UserResponse userResponse = UserMapper.toUserResponse(user);
+
+        return new KakaoLoginResponse(false, accessToken, userResponse);
     }
 }

--- a/src/main/java/com/example/soso/users/controller/SignupController.java
+++ b/src/main/java/com/example/soso/users/controller/SignupController.java
@@ -1,12 +1,12 @@
 package com.example.soso.users.controller;
 
 import com.example.soso.global.exception.domain.ErrorResponse;
-import com.example.soso.global.jwt.JwtTokenDto;
 import com.example.soso.users.domain.dto.AgeRangeRequest;
 import com.example.soso.users.domain.dto.BudgetRequest;
 import com.example.soso.users.domain.dto.ExperienceRequest;
 import com.example.soso.users.domain.dto.GenderRequest;
 import com.example.soso.users.domain.dto.RegionRequest;
+import com.example.soso.users.domain.dto.SignupCompleteResponse;
 import com.example.soso.users.domain.dto.UserTypeRequest;
 import com.example.soso.users.domain.entity.InterestRequest;
 import com.example.soso.users.domain.entity.SignupStep;
@@ -69,9 +69,11 @@ public class SignupController {
         @ApiResponse(responseCode = "200", description = "성공 - 다음 단계 반환",
             content = @Content(schema = @Schema(implementation = SignupStep.class))),
         @ApiResponse(responseCode = "400", description = "잘못된 요청",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = "{\"code\": \"BAD_REQUEST\", \"message\": \"유효하지 않은 사용자 유형입니다.\"}"))),
         @ApiResponse(responseCode = "401", description = "세션이 유효하지 않음",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = "{\"code\": \"UNAUTHORIZED\", \"message\": \"회원가입 세션이 만료되었습니다. 다시 로그인 해주세요.\"}")))
     })
     @PostMapping("/user-type")
     public ResponseEntity<SignupStep> setUserType(@RequestBody @Valid UserTypeRequest request,
@@ -99,9 +101,11 @@ public class SignupController {
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "성공 - 다음 단계 반환"),
         @ApiResponse(responseCode = "400", description = "잘못된 지역 코드",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = "{\"code\": \"BAD_REQUEST\", \"message\": \"유효하지 않은 지역 코드입니다.\"}"))),
         @ApiResponse(responseCode = "401", description = "세션이 유효하지 않음",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = "{\"code\": \"UNAUTHORIZED\", \"message\": \"회원가입 세션이 만료되었습니다. 다시 로그인 해주세요.\"}")))
     })
     @PostMapping("/region")
     public ResponseEntity<SignupStep> setRegion(@RequestBody @Valid RegionRequest request,
@@ -129,9 +133,11 @@ public class SignupController {
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "성공 - 다음 단계 반환"),
         @ApiResponse(responseCode = "400", description = "잘못된 연령대",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = "{\"code\": \"BAD_REQUEST\", \"message\": \"유효하지 않은 연령대입니다.\"}"))),
         @ApiResponse(responseCode = "401", description = "세션이 유효하지 않음",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = "{\"code\": \"UNAUTHORIZED\", \"message\": \"회원가입 세션이 만료되었습니다. 다시 로그인 해주세요.\"}")))
     })
     @PostMapping("/age-range")
     public ResponseEntity<SignupStep> setAgeRange(@RequestBody @Valid AgeRangeRequest request,
@@ -149,7 +155,8 @@ public class SignupController {
                 schema = @Schema(implementation = GenderRequest.class),
                 examples = {
                     @ExampleObject(name = "남성", value = "{\"gender\": \"MALE\"}"),
-                    @ExampleObject(name = "여성", value = "{\"gender\": \"FEMALE\"}")
+                    @ExampleObject(name = "여성", value = "{\"gender\": \"FEMALE\"}"),
+                    @ExampleObject(name = "선택 안함", value = "{\"gender\": \"NONE\"}")
                 }
             )
         )
@@ -157,9 +164,11 @@ public class SignupController {
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "성공 - 다음 단계 반환"),
         @ApiResponse(responseCode = "400", description = "잘못된 성별",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = "{\"code\": \"BAD_REQUEST\", \"message\": \"유효하지 않은 성별입니다.\"}"))),
         @ApiResponse(responseCode = "401", description = "세션이 유효하지 않음",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = "{\"code\": \"UNAUTHORIZED\", \"message\": \"회원가입 세션이 만료되었습니다. 다시 로그인 해주세요.\"}")))
     })
     @PostMapping("/gender")
     public ResponseEntity<SignupStep> setGender(@RequestBody @Valid GenderRequest request,
@@ -186,9 +195,11 @@ public class SignupController {
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "성공 - 다음 단계 반환"),
         @ApiResponse(responseCode = "400", description = "잘못된 업종 코드 또는 일반거주민 접근",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = "{\"code\": \"STEPS_NOT_TYPE\", \"message\": \"현재 진행 단계에서 허용되지 않는 요청입니다.\"}"))),
         @ApiResponse(responseCode = "401", description = "세션이 유효하지 않음",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = "{\"code\": \"UNAUTHORIZED\", \"message\": \"회원가입 세션이 만료되었습니다. 다시 로그인 해주세요.\"}")))
     })
     @PostMapping("/interests")
     public ResponseEntity<SignupStep> setInterests(@RequestBody @Valid InterestRequest request,
@@ -216,9 +227,11 @@ public class SignupController {
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "성공 - 다음 단계 반환"),
         @ApiResponse(responseCode = "400", description = "잘못된 예산 구간 또는 일반거주민 접근",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = "{\"code\": \"STEPS_NOT_TYPE\", \"message\": \"현재 진행 단계에서 허용되지 않는 요청입니다.\"}"))),
         @ApiResponse(responseCode = "401", description = "세션이 유효하지 않음",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = "{\"code\": \"UNAUTHORIZED\", \"message\": \"회원가입 세션이 만료되었습니다. 다시 로그인 해주세요.\"}")))
     })
     @PostMapping("/budget")
     public ResponseEntity<SignupStep> setBudget(@RequestBody @Valid BudgetRequest request,
@@ -244,9 +257,11 @@ public class SignupController {
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "성공 - 다음 단계 반환"),
         @ApiResponse(responseCode = "400", description = "잘못된 경험 값 또는 일반거주민 접근",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class))),
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = "{\"code\": \"STEPS_NOT_TYPE\", \"message\": \"현재 진행 단계에서 허용되지 않는 요청입니다.\"}"))),
         @ApiResponse(responseCode = "401", description = "세션이 유효하지 않음",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class),
+                examples = @ExampleObject(value = "{\"code\": \"UNAUTHORIZED\", \"message\": \"회원가입 세션이 만료되었습니다. 다시 로그인 해주세요.\"}")))
     })
     @PostMapping("/experience")
     public ResponseEntity<SignupStep> setExperience(@RequestBody @Valid ExperienceRequest request,
@@ -262,7 +277,8 @@ public class SignupController {
             @ApiResponse(responseCode = "200", description = "성공 - 생성된 닉네임 반환",
                 content = @Content(schema = @Schema(type = "string", example = "활발한코끼리123"))),
             @ApiResponse(responseCode = "401", description = "세션이 유효하지 않음",
-                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"code\": \"UNAUTHORIZED\", \"message\": \"회원가입 세션이 만료되었습니다. 다시 로그인 해주세요.\"}")))
         }
     )
     @PostMapping("/nickname")
@@ -274,22 +290,26 @@ public class SignupController {
 
     @Operation(
         summary = "[9단계] 회원가입 완료",
-        description = "회원가입을 완료하고 사용자 계정을 생성합니다. JWT 토큰을 발급하고 Refresh Token은 HttpOnly 쿠키로 설정됩니다.",
+        description = "회원가입을 완료하고 사용자 계정을 생성합니다. JWT 토큰 및 사용자 정보를 반환하며, Refresh Token은 HttpOnly 쿠키로 설정됩니다.",
         responses = {
-            @ApiResponse(responseCode = "200", description = "성공 - Access Token 반환",
+            @ApiResponse(responseCode = "200", description = "성공 - Access Token 및 사용자 정보 반환",
                 content = @Content(
-                    schema = @Schema(implementation = JwtTokenDto.class),
-                    examples = @ExampleObject(value = "{\"accessToken\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...\"}"))
-                ),
-            @ApiResponse(responseCode = "400", description = "회원가입 단계가 완료되지 않음"),
-            @ApiResponse(responseCode = "401", description = "세션이 유효하지 않음")
+                    schema = @Schema(implementation = SignupCompleteResponse.class),
+                    examples = @ExampleObject(value = "{\"accessToken\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...\", \"user\": {\"id\": \"550e8400-e29b-41d4-a716-446655440000\", \"username\": \"홍길동\", \"nickname\": \"길동이\", \"email\": \"user@example.com\"}}")
+                )),
+            @ApiResponse(responseCode = "400", description = "회원가입 단계가 완료되지 않음",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"code\": \"BAD_REQUEST\", \"message\": \"회원가입이 완료되지 않았습니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "세션이 유효하지 않음",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"code\": \"UNAUTHORIZED\", \"message\": \"회원가입 세션이 만료되었습니다. 다시 로그인 해주세요.\"}")))
         }
     )
     @PostMapping("/complete")
-    public ResponseEntity<JwtTokenDto> completeSignup(@Parameter(hidden = true) HttpSession session,
+    public ResponseEntity<SignupCompleteResponse> completeSignup(@Parameter(hidden = true) HttpSession session,
                                                       @Parameter(hidden = true) HttpServletResponse response) {
-        JwtTokenDto jwtAccessToken = signupService.completeSignup(session, response);
-        return ResponseEntity.ok(jwtAccessToken);
+        SignupCompleteResponse signupCompleteResponse = signupService.completeSignup(session, response);
+        return ResponseEntity.ok(signupCompleteResponse);
     }
 
     @Operation(
@@ -301,8 +321,12 @@ public class SignupController {
                     schema = @Schema(implementation = ExperienceRequest.class),
                     examples = @ExampleObject(value = "{\"experience\": \"YES\"}")
                 )),
-            @ApiResponse(responseCode = "400", description = "일반거주민 접근 또는 데이터 없음"),
-            @ApiResponse(responseCode = "401", description = "세션이 유효하지 않음")
+            @ApiResponse(responseCode = "400", description = "일반거주민 접근 또는 데이터 없음",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"code\": \"STEPS_NOT_TYPE\", \"message\": \"현재 진행 단계에서 허용되지 않는 요청입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "세션이 유효하지 않음",
+                content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"code\": \"UNAUTHORIZED\", \"message\": \"회원가입 세션이 만료되었습니다. 다시 로그인 해주세요.\"}")))
         }
     )
     @GetMapping("/experience/data")

--- a/src/main/java/com/example/soso/users/controller/UsersController.java
+++ b/src/main/java/com/example/soso/users/controller/UsersController.java
@@ -1,0 +1,68 @@
+package com.example.soso.users.controller;
+
+import com.example.soso.security.domain.CustomUserDetails;
+import com.example.soso.users.domain.dto.UserResponse;
+import com.example.soso.users.service.UsersService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Users", description = "사용자 정보 관련 API")
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UsersController {
+
+    private final UsersService usersService;
+
+    @Operation(
+            summary = "본인 정보 조회",
+            description = """
+                    현재 로그인한 사용자의 전체 정보를 조회합니다.
+
+                    **인증 필요:** JWT Access Token이 필요합니다.
+
+                    **응답 정보:**
+                    - 기본 정보: ID, 사용자명, 닉네임, 이메일
+                    - 프로필: 프로필 이미지 URL
+                    - 개인 정보: 성별, 연령대
+                    - 창업 정보: 사용자 유형, 예산, 창업 경험, 관심 업종
+                    - 위치 정보: 지역명, 위도, 경도
+                    - 시스템 정보: 생성일시, 수정일시
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "사용자 정보 조회 성공",
+                    content = @Content(schema = @Schema(implementation = UserResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "401",
+                    description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(ref = "#/components/schemas/ErrorResponse"))
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없음",
+                    content = @Content(schema = @Schema(ref = "#/components/schemas/ErrorResponse"))
+            )
+    })
+    @GetMapping("/me")
+    public ResponseEntity<UserResponse> getCurrentUser(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        UserResponse userResponse = usersService.getCurrentUserInfo(userDetails.getUsername());
+        return ResponseEntity.ok(userResponse);
+    }
+
+}

--- a/src/main/java/com/example/soso/users/domain/dto/SignupCompleteResponse.java
+++ b/src/main/java/com/example/soso/users/domain/dto/SignupCompleteResponse.java
@@ -1,0 +1,14 @@
+package com.example.soso.users.domain.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원가입 완료 응답")
+public record SignupCompleteResponse(
+
+        @Schema(description = "Access Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", requiredMode = Schema.RequiredMode.REQUIRED)
+        String accessToken,
+
+        @Schema(description = "사용자 정보", requiredMode = Schema.RequiredMode.REQUIRED)
+        UserResponse user
+
+) {}

--- a/src/main/java/com/example/soso/users/domain/dto/UserMapper.java
+++ b/src/main/java/com/example/soso/users/domain/dto/UserMapper.java
@@ -3,6 +3,8 @@ package com.example.soso.users.domain.dto;
 import com.example.soso.community.common.post.domain.dto.UserSummaryResponse;
 import com.example.soso.users.domain.entity.Users;
 
+import java.util.stream.Collectors;
+
 public class UserMapper {
 
     public static Users fromSignupSession(SignupSession session, String username, String email, String profileImageUrl) {
@@ -23,6 +25,31 @@ public class UserMapper {
 
     public static UserSummaryResponse toUserSummary(Users users){
         return new UserSummaryResponse(users.getId(), users.getUsername(), users.getLocation(), users.getProfileImageUrl(), users.getUserType());
+    }
+
+    public static UserResponse toUserResponse(Users user) {
+        return UserResponse.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .userType(user.getUserType())
+                .profileImageUrl(user.getProfileImageUrl())
+                .gender(user.getGender())
+                .ageRange(user.getAgeRange())
+                .budget(user.getBudget() != null ? user.getBudget().getLabel() : null)
+                .startupExperience(user.getStartupExperience() != null ? user.getStartupExperience().getLabel() : null)
+                .location(user.getLocation())
+                .interests(user.getInterests() != null
+                        ? user.getInterests().stream()
+                                .map(interest -> interest.getLabel())
+                                .collect(Collectors.toList())
+                        : null)
+                .latitude(user.getLatitude())
+                .longitude(user.getLongitude())
+                .createdDate(user.getCreatedDate())
+                .lastModifiedDate(user.getLastModifiedDate())
+                .build();
     }
 
 }

--- a/src/main/java/com/example/soso/users/domain/dto/UserResponse.java
+++ b/src/main/java/com/example/soso/users/domain/dto/UserResponse.java
@@ -13,19 +13,19 @@ import java.util.List;
 @Schema(description = "사용자 정보 응답")
 public class UserResponse {
 
-    @Schema(description = "사용자 ID (UUID)", example = "550e8400-e29b-41d4-a716-446655440000")
+    @Schema(description = "사용자 ID (UUID)", example = "550e8400-e29b-41d4-a716-446655440000", requiredMode = Schema.RequiredMode.REQUIRED)
     private String id;
 
-    @Schema(description = "사용자명", example = "홍길동")
+    @Schema(description = "사용자명", example = "홍길동", requiredMode = Schema.RequiredMode.REQUIRED)
     private String username;
 
-    @Schema(description = "닉네임", example = "길동이")
+    @Schema(description = "닉네임", example = "길동이", requiredMode = Schema.RequiredMode.REQUIRED)
     private String nickname;
 
-    @Schema(description = "이메일", example = "user@example.com")
+    @Schema(description = "이메일", example = "user@example.com", requiredMode = Schema.RequiredMode.REQUIRED)
     private String email;
 
-    @Schema(description = "사용자 유형 (FOUNDER: 예비 창업자, INHABITANT: 일반 거주민)", example = "FOUNDER")
+    @Schema(description = "사용자 유형 (FOUNDER: 예비 창업자, INHABITANT: 일반 거주민)", example = "FOUNDER", requiredMode = Schema.RequiredMode.REQUIRED)
     private UserType userType;
 
     @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
@@ -43,7 +43,7 @@ public class UserResponse {
     @Schema(description = "창업 경험 여부", example = "창업 경험 유")
     private String startupExperience;
 
-    @Schema(description = "지역명", example = "서울시 강남구")
+    @Schema(description = "지역명", example = "서울시 강남구", requiredMode = Schema.RequiredMode.REQUIRED)
     private String location;
 
     @Schema(description = "관심 업종 목록")
@@ -55,9 +55,9 @@ public class UserResponse {
     @Schema(description = "경도", example = "126.9780")
     private String longitude;
 
-    @Schema(description = "계정 생성일시", example = "2024-01-01T00:00:00")
+    @Schema(description = "계정 생성일시", example = "2024-01-01T00:00:00", requiredMode = Schema.RequiredMode.REQUIRED)
     private LocalDateTime createdDate;
 
-    @Schema(description = "마지막 수정일시", example = "2024-01-01T00:00:00")
+    @Schema(description = "마지막 수정일시", example = "2024-01-01T00:00:00", requiredMode = Schema.RequiredMode.REQUIRED)
     private LocalDateTime lastModifiedDate;
 }

--- a/src/main/java/com/example/soso/users/domain/dto/UserResponse.java
+++ b/src/main/java/com/example/soso/users/domain/dto/UserResponse.java
@@ -1,0 +1,63 @@
+package com.example.soso.users.domain.dto;
+
+import com.example.soso.users.domain.entity.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "사용자 정보 응답")
+public class UserResponse {
+
+    @Schema(description = "사용자 ID (UUID)", example = "550e8400-e29b-41d4-a716-446655440000")
+    private String id;
+
+    @Schema(description = "사용자명", example = "홍길동")
+    private String username;
+
+    @Schema(description = "닉네임", example = "길동이")
+    private String nickname;
+
+    @Schema(description = "이메일", example = "user@example.com")
+    private String email;
+
+    @Schema(description = "사용자 유형 (FOUNDER: 예비 창업자, INHABITANT: 일반 거주민)", example = "FOUNDER")
+    private UserType userType;
+
+    @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
+    private String profileImageUrl;
+
+    @Schema(description = "성별 (MALE: 남성, FEMALE: 여성)", example = "MALE")
+    private Gender gender;
+
+    @Schema(description = "연령대", example = "TWENTIES")
+    private AgeRange ageRange;
+
+    @Schema(description = "예산 구간", example = "3~5천")
+    private String budget;
+
+    @Schema(description = "창업 경험 여부", example = "창업 경험 유")
+    private String startupExperience;
+
+    @Schema(description = "지역명", example = "서울시 강남구")
+    private String location;
+
+    @Schema(description = "관심 업종 목록")
+    private List<String> interests;
+
+    @Schema(description = "위도", example = "37.5665")
+    private String latitude;
+
+    @Schema(description = "경도", example = "126.9780")
+    private String longitude;
+
+    @Schema(description = "계정 생성일시", example = "2024-01-01T00:00:00")
+    private LocalDateTime createdDate;
+
+    @Schema(description = "마지막 수정일시", example = "2024-01-01T00:00:00")
+    private LocalDateTime lastModifiedDate;
+}

--- a/src/main/java/com/example/soso/users/domain/dto/UserResponse.java
+++ b/src/main/java/com/example/soso/users/domain/dto/UserResponse.java
@@ -31,10 +31,10 @@ public class UserResponse {
     @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
     private String profileImageUrl;
 
-    @Schema(description = "성별 (MALE: 남성, FEMALE: 여성)", example = "MALE")
+    @Schema(description = "성별 (MALE: 남성, FEMALE: 여성, NONE: 선택 안함)", example = "MALE", requiredMode = Schema.RequiredMode.REQUIRED)
     private Gender gender;
 
-    @Schema(description = "연령대", example = "TWENTIES")
+    @Schema(description = "연령대", example = "TWENTIES", requiredMode = Schema.RequiredMode.REQUIRED)
     private AgeRange ageRange;
 
     @Schema(description = "예산 구간", example = "3~5천")

--- a/src/main/java/com/example/soso/users/domain/entity/Gender.java
+++ b/src/main/java/com/example/soso/users/domain/entity/Gender.java
@@ -11,5 +11,8 @@ public enum Gender {
     MALE,
 
     @Schema(description = "여성")
-    FEMALE
+    FEMALE,
+
+    @Schema(description = "선택 안함")
+    NONE
 }

--- a/src/main/java/com/example/soso/users/service/SignupService.java
+++ b/src/main/java/com/example/soso/users/service/SignupService.java
@@ -1,11 +1,11 @@
 package com.example.soso.users.service;
 
-import com.example.soso.global.jwt.JwtTokenDto;
 import com.example.soso.users.domain.dto.AgeRangeRequest;
 import com.example.soso.users.domain.dto.BudgetRequest;
 import com.example.soso.users.domain.dto.ExperienceRequest;
 import com.example.soso.users.domain.dto.GenderRequest;
 import com.example.soso.users.domain.dto.RegionRequest;
+import com.example.soso.users.domain.dto.SignupCompleteResponse;
 import com.example.soso.users.domain.entity.AgeRange;
 import com.example.soso.users.domain.entity.BudgetRange;
 import com.example.soso.users.domain.entity.Gender;
@@ -36,7 +36,7 @@ public interface SignupService {
 
     String saveNickname(HttpSession session);
 
-    JwtTokenDto completeSignup(HttpSession session, HttpServletResponse response);
+    SignupCompleteResponse completeSignup(HttpSession session, HttpServletResponse response);
 
     // 조회 메서드 (뒤로가기 용)
     RegionRequest getRegion(HttpSession session);

--- a/src/main/java/com/example/soso/users/service/SignupServiceImpl.java
+++ b/src/main/java/com/example/soso/users/service/SignupServiceImpl.java
@@ -7,16 +7,17 @@ import static com.example.soso.global.exception.domain.UserErrorCode.STEPS_NOT_T
 import com.example.soso.global.exception.util.UserAuthException;
 import com.example.soso.global.jwt.JwtProperties;
 import com.example.soso.global.jwt.JwtProvider;
-import com.example.soso.global.jwt.JwtTokenDto;
 import com.example.soso.global.redis.RefreshTokenRedisRepository;
 import com.example.soso.users.domain.dto.AgeRangeRequest;
 import com.example.soso.users.domain.dto.BudgetRequest;
 import com.example.soso.users.domain.dto.ExperienceRequest;
 import com.example.soso.users.domain.dto.GenderRequest;
 import com.example.soso.users.domain.dto.RegionRequest;
+import com.example.soso.users.domain.dto.SignupCompleteResponse;
 import com.example.soso.users.domain.dto.SignupSession;
 import com.example.soso.users.domain.dto.TokenPair;
 import com.example.soso.users.domain.dto.UserMapper;
+import com.example.soso.users.domain.dto.UserResponse;
 import com.example.soso.users.domain.entity.AgeRange;
 import com.example.soso.users.domain.entity.BudgetRange;
 import com.example.soso.users.domain.entity.Gender;
@@ -188,7 +189,7 @@ public class SignupServiceImpl implements SignupService {
      * 9단계: 회원가입 완료.
      * 저장된 세션 정보를 기반으로 Users 엔터티를 생성하고 토큰을 발급한다.
      */
-    public JwtTokenDto completeSignup(HttpSession session, HttpServletResponse response) {
+    public SignupCompleteResponse completeSignup(HttpSession session, HttpServletResponse response) {
         // 마지막 단계 검증 및 확인
         SignupSession signup = getValidatedSession(session);
         validateStep(signup, SignupStep.COMPLETE);
@@ -204,9 +205,12 @@ public class SignupServiceImpl implements SignupService {
         redisService.saveByUserId(user.getId(), tokenPair.refreshToken(), jwtProperties.getRefreshTokenValidityInMs());
         addRefreshTokenCookie(response, tokenPair.refreshToken(), jwtProperties.getRefreshTokenValidityInMs());
 
+        // UserResponse 생성
+        UserResponse userResponse = UserMapper.toUserResponse(user);
+
         // 세션 삭제
         session.removeAttribute("signup");
-        return new JwtTokenDto(tokenPair.accessToken());
+        return new SignupCompleteResponse(tokenPair.accessToken(), userResponse);
     }
 
     private TokenPair generateTokens(String userId) {

--- a/src/main/java/com/example/soso/users/service/UsersService.java
+++ b/src/main/java/com/example/soso/users/service/UsersService.java
@@ -1,0 +1,14 @@
+package com.example.soso.users.service;
+
+import com.example.soso.users.domain.dto.UserResponse;
+
+public interface UsersService {
+
+    /**
+     * 현재 로그인한 사용자의 정보를 조회합니다.
+     * @param userId 사용자 ID
+     * @return 사용자 정보
+     */
+    UserResponse getCurrentUserInfo(String userId);
+
+}

--- a/src/main/java/com/example/soso/users/service/UsersServiceImpl.java
+++ b/src/main/java/com/example/soso/users/service/UsersServiceImpl.java
@@ -1,0 +1,28 @@
+package com.example.soso.users.service;
+
+import com.example.soso.global.exception.domain.UserErrorCode;
+import com.example.soso.global.exception.util.UserAuthException;
+import com.example.soso.users.domain.dto.UserMapper;
+import com.example.soso.users.domain.dto.UserResponse;
+import com.example.soso.users.domain.entity.Users;
+import com.example.soso.users.repository.UsersRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UsersServiceImpl implements UsersService {
+
+    private final UsersRepository usersRepository;
+
+    @Override
+    public UserResponse getCurrentUserInfo(String userId) {
+        Users user = usersRepository.findById(userId)
+                .orElseThrow(() -> new UserAuthException(UserErrorCode.USER_NOT_FOUND));
+
+        return UserMapper.toUserResponse(user);
+    }
+
+}

--- a/src/test/java/com/example/soso/users/controller/SignupControllerIntegrationTest.java
+++ b/src/test/java/com/example/soso/users/controller/SignupControllerIntegrationTest.java
@@ -147,7 +147,9 @@ class SignupControllerIntegrationTest {
         mockMvc.perform(post("/signup/complete")
                         .session(mockSession))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.jwtAccessToken").isNotEmpty());
+                .andExpect(jsonPath("$.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.user").exists())
+                .andExpect(jsonPath("$.user.id").exists());
 
         // 데이터베이스에 사용자가 저장되었는지 확인
         long userCountAfter = usersRepository.count();
@@ -212,7 +214,9 @@ class SignupControllerIntegrationTest {
         mockMvc.perform(post("/signup/complete")
                         .session(mockSession))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.jwtAccessToken").isNotEmpty());
+                .andExpect(jsonPath("$.accessToken").isNotEmpty())
+                .andExpect(jsonPath("$.user").exists())
+                .andExpect(jsonPath("$.user.id").exists());
 
         long userCountAfter = usersRepository.count();
         assertThat(userCountAfter).isEqualTo(userCountBefore + 1);

--- a/src/test/java/com/example/soso/users/controller/SignupControllerTest.java
+++ b/src/test/java/com/example/soso/users/controller/SignupControllerTest.java
@@ -8,11 +8,16 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.example.soso.global.jwt.JwtTokenDto;
 import com.example.soso.users.domain.dto.ExperienceRequest;
+import com.example.soso.users.domain.dto.SignupCompleteResponse;
+import com.example.soso.users.domain.dto.UserResponse;
+import com.example.soso.users.domain.entity.AgeRange;
+import com.example.soso.users.domain.entity.Gender;
 import com.example.soso.users.domain.entity.SignupStep;
 import com.example.soso.users.domain.entity.StartupExperience;
+import com.example.soso.users.domain.entity.UserType;
 import com.example.soso.users.service.SignupService;
+import java.time.LocalDateTime;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
@@ -65,14 +70,29 @@ class SignupControllerTest {
     }
 
     @Test
-    @DisplayName("회원가입 완료 시 JWT 토큰을 반환한다")
+    @DisplayName("회원가입 완료 시 JWT 토큰 및 사용자 정보를 반환한다")
     void postComplete() throws Exception {
+        UserResponse userResponse = UserResponse.builder()
+                .id("test-id")
+                .username("테스트")
+                .nickname("테스터")
+                .email("test@example.com")
+                .userType(UserType.FOUNDER)
+                .gender(Gender.MALE)
+                .ageRange(AgeRange.TWENTIES)
+                .location("서울시 강남구")
+                .createdDate(LocalDateTime.now())
+                .lastModifiedDate(LocalDateTime.now())
+                .build();
+
+        SignupCompleteResponse response = new SignupCompleteResponse("access", userResponse);
+
         when(signupService.completeSignup(any(HttpSession.class), any(HttpServletResponse.class)))
-                .thenReturn(new JwtTokenDto("access"));
+                .thenReturn(response);
 
         mockMvc.perform(post("/signup/complete"))
                 .andExpect(status().isOk())
-                .andExpect(content().json("{\"jwtAccessToken\":\"access\"}"));
+                .andExpect(content().json("{\"accessToken\":\"access\"}"));
     }
 
     @Test

--- a/src/test/java/com/example/soso/users/controller/UsersControllerTest.java
+++ b/src/test/java/com/example/soso/users/controller/UsersControllerTest.java
@@ -1,0 +1,137 @@
+package com.example.soso.users.controller;
+
+import com.example.soso.security.domain.CustomUserDetails;
+import com.example.soso.users.domain.dto.UserResponse;
+import com.example.soso.users.domain.entity.*;
+import com.example.soso.users.service.UsersService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureWebMvc
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=MySQL;DATABASE_TO_LOWER=TRUE;CASE_INSENSITIVE_IDENTIFIERS=TRUE",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+        "spring.session.store-type=none",
+        "jwt.secret-key=test-jwt-secret-key-that-is-sufficiently-long-and-secure-for-testing-purposes-minimum-256-bits-required-by-jwt-library",
+        "jwt.access-token-validity-in-ms=1800000",
+        "jwt.refresh-token-validity-in-ms=1209600000"
+})
+@Transactional
+@DisplayName("사용자 정보 컨트롤러 테스트")
+class UsersControllerTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @MockitoBean
+    private UsersService usersService;
+
+    private MockMvc mockMvc;
+    private CustomUserDetails testUserDetails;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .build();
+
+        Users testUser = Users.builder()
+                .username("홍길동")
+                .nickname("길동이")
+                .email("test@example.com")
+                .userType(UserType.FOUNDER)
+                .profileImageUrl("https://example.com/profile.jpg")
+                .gender(Gender.MALE)
+                .ageRange(AgeRange.TWENTIES)
+                .budget(BudgetRange.THOUSANDS_3000_5000)
+                .startupExperience(StartupExperience.YES)
+                .location("서울시 강남구")
+                .interests(Arrays.asList(InterestType.MANUFACTURING, InterestType.WHOLESALE_RETAIL))
+                .latitude("37.5665")
+                .longitude("126.9780")
+                .build();
+
+        try {
+            java.lang.reflect.Field idField = Users.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(testUser, "test-user-id-123");
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set user id", e);
+        }
+
+        testUserDetails = new CustomUserDetails(testUser);
+    }
+
+    @Test
+    @DisplayName("본인 정보 조회 - 성공")
+    void getCurrentUser_Success() throws Exception {
+        // Given
+        UserResponse mockResponse = UserResponse.builder()
+                .id("test-user-id-123")
+                .username("홍길동")
+                .nickname("길동이")
+                .email("test@example.com")
+                .userType(UserType.FOUNDER)
+                .profileImageUrl("https://example.com/profile.jpg")
+                .gender(Gender.MALE)
+                .ageRange(AgeRange.TWENTIES)
+                .budget("3~5천")
+                .startupExperience("창업 경험 유")
+                .location("서울시 강남구")
+                .interests(Arrays.asList("식료품 등 제조업", "도매 및 소매업"))
+                .latitude("37.5665")
+                .longitude("126.9780")
+                .createdDate(LocalDateTime.now())
+                .lastModifiedDate(LocalDateTime.now())
+                .build();
+
+        when(usersService.getCurrentUserInfo(anyString())).thenReturn(mockResponse);
+
+        // When & Then
+        mockMvc.perform(get("/users/me")
+                        .with(SecurityMockMvcRequestPostProcessors.user(testUserDetails)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value("test-user-id-123"))
+                .andExpect(jsonPath("$.username").value("홍길동"))
+                .andExpect(jsonPath("$.nickname").value("길동이"))
+                .andExpect(jsonPath("$.email").value("test@example.com"))
+                .andExpect(jsonPath("$.userType").value("FOUNDER"))
+                .andExpect(jsonPath("$.gender").value("MALE"))
+                .andExpect(jsonPath("$.ageRange").value("TWENTIES"))
+                .andExpect(jsonPath("$.budget").value("3~5천"))
+                .andExpect(jsonPath("$.startupExperience").value("창업 경험 유"))
+                .andExpect(jsonPath("$.location").value("서울시 강남구"))
+                .andExpect(jsonPath("$.interests[0]").value("식료품 등 제조업"))
+                .andExpect(jsonPath("$.interests[1]").value("도매 및 소매업"))
+                .andExpect(jsonPath("$.latitude").value("37.5665"))
+                .andExpect(jsonPath("$.longitude").value("126.9780"));
+    }
+
+}

--- a/src/test/java/com/example/soso/users/service/SignupServiceTest.java
+++ b/src/test/java/com/example/soso/users/service/SignupServiceTest.java
@@ -3,7 +3,6 @@ package com.example.soso.users.service;
 import com.example.soso.global.exception.util.UserAuthException;
 import com.example.soso.global.jwt.JwtProperties;
 import com.example.soso.global.jwt.JwtProvider;
-import com.example.soso.global.jwt.JwtTokenDto;
 import com.example.soso.global.redis.RefreshTokenRedisRepository;
 import com.example.soso.users.domain.dto.*;
 import com.example.soso.users.domain.entity.*;
@@ -276,19 +275,35 @@ class SignupServiceTest {
             signupSession.setEmail("test@example.com");
             signupSession.setProfileImageUrl("https://example.com/profile.jpg");
             signupSession.setNickname("테스트문어");
+            signupSession.setGender(Gender.MALE);
+            signupSession.setAgeRange(AgeRange.TWENTIES);
+            signupSession.setRegionId("11010");
 
             Users mockUser = mock(Users.class);
+            when(mockUser.getId()).thenReturn("test-user-id");
+            when(mockUser.getUsername()).thenReturn("testUser");
+            when(mockUser.getNickname()).thenReturn("테스트문어");
+            when(mockUser.getEmail()).thenReturn("test@example.com");
+            when(mockUser.getUserType()).thenReturn(UserType.FOUNDER);
+            when(mockUser.getGender()).thenReturn(Gender.MALE);
+            when(mockUser.getAgeRange()).thenReturn(AgeRange.TWENTIES);
+            when(mockUser.getLocation()).thenReturn("서울시 종로구");
+            when(mockUser.getCreatedDate()).thenReturn(java.time.LocalDateTime.now());
+            when(mockUser.getLastModifiedDate()).thenReturn(java.time.LocalDateTime.now());
+
             when(usersRepository.save(any(Users.class))).thenReturn(mockUser);
             when(jwtProvider.generateAccessToken(any())).thenReturn("accessToken");
             when(jwtProvider.generateRefreshToken()).thenReturn("refreshToken");
             when(jwtProperties.getRefreshTokenValidityInMs()).thenReturn(1209600000L);
 
             // when
-            JwtTokenDto result = signupService.completeSignup(mockSession, httpServletResponse);
+            SignupCompleteResponse result = signupService.completeSignup(mockSession, httpServletResponse);
 
             // then
             assertThat(result).isNotNull();
-            assertThat(result.jwtAccessToken()).isEqualTo("accessToken");
+            assertThat(result.accessToken()).isEqualTo("accessToken");
+            assertThat(result.user()).isNotNull();
+            assertThat(result.user().getId()).isEqualTo("test-user-id");
             assertThat(mockSession.getAttribute("signup")).isNull(); // 세션 정리됨
 
             verify(usersRepository).save(any(Users.class));

--- a/src/test/java/com/example/soso/users/util/JwtTokenGenerator.java
+++ b/src/test/java/com/example/soso/users/util/JwtTokenGenerator.java
@@ -1,0 +1,32 @@
+package com.example.soso.users.util;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+public class JwtTokenGenerator {
+
+    private static final String SECRET_KEY = "my-secret-12345678901234567890123456789012";
+    private static final long VALIDITY = 1800000; // 30 minutes
+
+    public static void main(String[] args) {
+        String userId = "test-user-123";
+
+        SecretKey key = Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8));
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + VALIDITY);
+
+        String token = Jwts.builder()
+                .setSubject(userId)
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key)
+                .compact();
+
+        System.out.println("Generated JWT Token for user: " + userId);
+        System.out.println(token);
+    }
+}


### PR DESCRIPTION
# feat: 사용자 정보 조회 API 및 회원가입/로그인 응답 개선

## 📋 Summary

사용자 정보 조회를 위한 새로운 API (`GET /users/me`)를 추가하고, 회원가입 완료(`POST /signup/complete`)와 카카오 로그인(`POST /auth/kakao/login`) 응답에 사용자 정보를 포함하도록 개선했습니다.

## 🎯 Motivation

### 기존 상황
- 회원가입/로그인 API는 **Access Token만** 반환
- 사용자 정보를 조회할 수 있는 API가 없음
- 프론트엔드에서 로그인 후 사용자 정보를 얻을 방법이 없음

### 개선 사항
1. **사용자 정보 조회 API 추가** (`GET /users/me`)
   - JWT 인증 기반으로 본인의 사용자 정보 조회
   - 페이지 새로고침, 토큰 기반 사용자 정보 복구 시 사용

2. **회원가입/로그인 응답 개선**
   - Access Token과 함께 사용자 정보를 즉시 반환
   - 회원가입/로그인 후 추가 API 호출 없이 바로 사용자 정보 사용 가능
   - 초기 로딩 시간 단축

3. **일관된 사용자 정보 구조**
   - 모든 API에서 동일한 `UserResponse` DTO 사용
   - `gender`, `ageRange` 필드를 필수로 설정하여 타입 안정성 보장

## 🔄 Changes

### 1. 사용자 정보 조회 API 추가 (`GET /users/me`)

#### 새로 추가된 파일
- `UsersController.java` - 사용자 정보 조회 컨트롤러
- `UsersService.java` / `UsersServiceImpl.java` - 사용자 정보 조회 서비스
- `UserResponse.java` - 사용자 정보 응답 DTO
- `UsersControllerTest.java` - 단위 테스트

#### API 명세
```java
@GetMapping("/me")
@Operation(summary = "내 정보 조회", description = "JWT 토큰으로 인증된 사용자 본인의 정보를 조회합니다.")
public ResponseEntity<UserResponse> getMyInfo(@AuthenticationPrincipal String userId) {
    UserResponse userResponse = usersService.getMyInfo(userId);
    return ResponseEntity.ok(userResponse);
}
```

### 2. 새로운 DTO 추가 (회원가입/로그인 응답용)

#### `SignupCompleteResponse.java`
```java
public record SignupCompleteResponse(
    @Schema(description = "Access Token", requiredMode = REQUIRED)
    String accessToken,

    @Schema(description = "사용자 정보", requiredMode = REQUIRED)
    UserResponse user
) {}
```

#### `KakaoLoginResponse.java`
```java
public record KakaoLoginResponse(
    @Schema(description = "신규 사용자 여부", requiredMode = REQUIRED)
    boolean isNewUser,

    @Schema(description = "Access Token (기존 사용자인 경우에만 제공)")
    String accessToken,

    @Schema(description = "사용자 정보 (기존 사용자인 경우에만 제공)")
    UserResponse user
) {}
```

### 3. Service 계층 수정

#### `SignupServiceImpl.java`
- `completeSignup()` 메서드 반환 타입 변경: `JwtTokenDto` → `SignupCompleteResponse`
- 회원가입 완료 시 사용자 엔티티를 `UserResponse`로 변환하여 함께 반환

```java
public SignupCompleteResponse completeSignup(HttpSession session, HttpServletResponse response) {
    // ... 기존 로직
    Users user = UserMapper.fromSignupSession(signup, ...);
    usersRepository.save(user);

    TokenPair tokenPair = generateTokens(user.getId());
    UserResponse userResponse = UserMapper.toUserResponse(user);  // 추가

    return new SignupCompleteResponse(tokenPair.accessToken(), userResponse);
}
```

#### `UserLoginService.java`
- 카카오 로그인 시 사용자 정보 조회 및 `UserResponse` 생성
- `KakaoLoginResponse` 반환 (기존 사용자만 user 필드 포함)

```java
public KakaoLoginResponse login(String email, HttpServletResponse response) {
    Users user = userRepository.findByEmail(email).orElseThrow(...);

    String accessToken = jwtProvider.generateAccessToken(user.getId());
    UserResponse userResponse = UserMapper.toUserResponse(user);  // 추가

    return new KakaoLoginResponse(false, accessToken, userResponse);
}
```

#### `KakaoServiceImpl.java`
- 신규 사용자: `new KakaoLoginResponse(true, null, null)`
- 기존 사용자: `userLoginService.login()` 호출하여 토큰 + 사용자 정보 반환

### 4. Controller 수정

#### `SignupController.java`
```java
@PostMapping("/complete")
public ResponseEntity<SignupCompleteResponse> completeSignup(...) {
    SignupCompleteResponse response = signupService.completeSignup(session, response);
    return ResponseEntity.ok(response);
}
```

#### `KakaoAuthController.java`
```java
@PostMapping("/login")
public ResponseEntity<KakaoLoginResponse> kakaoLogin(...) {
    KakaoLoginResponse result = kakaoService.login(...);
    return ResponseEntity.ok(result);
}
```

### 5. UserResponse 필드 수정

#### `UserResponse.java`
- `gender`와 `ageRange` 필드를 **required**로 변경
- 프론트엔드에서 옵셔널 타입이 아닌 필수 타입으로 생성되도록 보장

```java
@Schema(description = "성별 (MALE: 남성, FEMALE: 여성, NONE: 선택 안함)",
        requiredMode = Schema.RequiredMode.REQUIRED)
private Gender gender;

@Schema(description = "연령대",
        requiredMode = Schema.RequiredMode.REQUIRED)
private AgeRange ageRange;
```

### 6. Gender Enum에 NONE 옵션 추가

#### `Gender.java`
- 성별 선택 안함 옵션 추가: `MALE`, `FEMALE`, `NONE`
- 사용자가 성별을 선택하지 않아도 회원가입 가능

### 7. Swagger 문서 업데이트

#### 회원가입 완료 API
```yaml
/signup/complete:
  post:
    responses:
      200:
        description: 성공 - Access Token 및 사용자 정보 반환
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/SignupCompleteResponse'
            example:
              accessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
              user:
                id: "550e8400-e29b-41d4-a716-446655440000"
                username: "홍길동"
                nickname: "길동이"
                email: "user@example.com"
                gender: "MALE"
                ageRange: "TWENTIES"
```

#### 카카오 로그인 API
```yaml
/auth/kakao/login:
  post:
    responses:
      200:
        description: 로그인 성공
        content:
          application/json:
            examples:
              기존 사용자:
                value:
                  isNewUser: false
                  accessToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
                  user: { ... }
              신규 사용자:
                value:
                  isNewUser: true
                  accessToken: null
                  user: null
```

## 📊 API Response Structure

### Before (기존)
```typescript
// 회원가입 완료 - 토큰만 반환
POST /signup/complete
Response: { jwtAccessToken: string }

// 카카오 로그인 - 토큰만 반환
POST /auth/kakao/login
Response: {
  isNewUser: boolean,
  jwtAccessToken?: string
}

// ❌ 사용자 정보 조회 API 없음
```

### After (개선)
```typescript
// 1. 새로 추가된 API - 사용자 정보 조회
GET /users/me
Headers: { Authorization: "Bearer {accessToken}" }
Response: UserResponse

// 2. 회원가입 완료 - 토큰 + 사용자 정보 함께 반환
POST /signup/complete
Response: {
  accessToken: string,
  user: UserResponse
}

// 3. 카카오 로그인 - 기존 사용자 (토큰 + 사용자 정보)
POST /auth/kakao/login
Response: {
  isNewUser: false,
  accessToken: string,
  user: UserResponse
}

// 4. 카카오 로그인 - 신규 사용자
POST /auth/kakao/login
Response: {
  isNewUser: true,
  accessToken: null,
  user: null
}
```

### API 역할 구분

**`GET /users/me`**
- JWT 인증 필수
- 페이지 새로고침 시 사용자 정보 복구
- 토큰은 있지만 사용자 정보가 없을 때
- 사용자 정보 업데이트 후 최신 정보 조회

**`POST /signup/complete`, `POST /auth/kakao/login`**
- 회원가입/로그인 시 즉시 사용자 정보 제공
- 추가 API 호출 없이 바로 화면 전환 가능
- 초기 로딩 시간 단축

## 🎨 Frontend Impact (Orval)

### 생성될 TypeScript 타입

```typescript
export interface SignupCompleteResponse {
  accessToken: string;     // required
  user: UserResponse;      // required
}

export interface KakaoLoginResponse {
  isNewUser: boolean;      // required
  accessToken?: string;    // optional
  user?: UserResponse;     // optional
}

export interface UserResponse {
  id: string;
  username: string;
  nickname: string;
  email: string;
  userType: 'FOUNDER' | 'INHABITANT';
  gender: 'MALE' | 'FEMALE' | 'NONE';     // ✅ required (not optional)
  ageRange: 'TEENS' | 'TWENTIES' | ...;   // ✅ required (not optional)
  location: string;
  createdDate: string;
  lastModifiedDate: string;
  profileImageUrl?: string;
  budget?: string;
  startupExperience?: string;
  interests?: string[];
  latitude?: string;
  longitude?: string;
}
```

### 사용 예시

```typescript
// 회원가입 후 즉시 사용자 정보 사용 가능
const { accessToken, user } = await signupComplete();
setToken(accessToken);
setUser(user);  // 추가 API 호출 불필요!
console.log(user.gender);    // type-safe: 'MALE' | 'FEMALE' | 'NONE'
console.log(user.ageRange);  // type-safe: 'TEENS' | 'TWENTIES' | ...

// 카카오 로그인 - 타입 가드로 안전하게 처리
const response = await kakaoLogin(code);
if (!response.isNewUser && response.user) {
  // 기존 사용자: 바로 로그인 처리
  setToken(response.accessToken!);
  setUser(response.user);
  navigate('/home');
} else {
  // 신규 사용자: 회원가입 플로우로 이동
  navigate('/signup');
}
```

## 🔍 Testing

### Unit Tests
- ✅ `SignupServiceTest`: completeSignup 반환 타입 검증
- ✅ `SignupControllerTest`: 응답 JSON 구조 검증
- ✅ `UsersControllerTest`: /users/me 응답 검증

### Integration Tests
- ✅ `SignupControllerIntegrationTest`: 전체 회원가입 플로우 검증
- ✅ Docker 환경에서 MySQL, Redis와 연동 테스트

### Manual Tests
- ✅ Swagger UI를 통한 API 테스트
- ✅ OpenAPI 스펙 검증 (Orval 호환성)
- ✅ 로컬 및 Docker 환경에서 실행 확인

## 📝 OpenAPI Spec Validation

### SignupCompleteResponse
```json
{
  "required": ["accessToken", "user"],
  "properties": {
    "accessToken": { "type": "string" },
    "user": { "$ref": "#/components/schemas/UserResponse" }
  }
}
```

### KakaoLoginResponse
```json
{
  "required": ["isNewUser"],
  "properties": {
    "isNewUser": { "type": "boolean" },
    "accessToken": { "type": "string" },
    "user": { "$ref": "#/components/schemas/UserResponse" }
  }
}
```

### UserResponse Required Fields
```json
{
  "required": [
    "id", "username", "nickname", "email", "userType",
    "gender", "ageRange", "location",
    "createdDate", "lastModifiedDate"
  ]
}
```

## 📦 Files Changed

### New Files (사용자 정보 조회 API 추가)
- `src/main/java/com/example/soso/users/controller/UsersController.java`
- `src/main/java/com/example/soso/users/service/UsersService.java`
- `src/main/java/com/example/soso/users/service/UsersServiceImpl.java`
- `src/main/java/com/example/soso/users/domain/dto/UserResponse.java`
- `src/test/java/com/example/soso/users/controller/UsersControllerTest.java`
- `src/test/java/com/example/soso/users/util/JwtTokenGenerator.java`

### New Files (회원가입/로그인 응답 개선)
- `src/main/java/com/example/soso/users/domain/dto/SignupCompleteResponse.java`
- `src/main/java/com/example/soso/kakao/dto/KakaoLoginResponse.java`

### Modified Files
- `src/main/java/com/example/soso/users/domain/dto/UserResponse.java` - gender, ageRange 필수 필드로 변경
- `src/main/java/com/example/soso/users/domain/dto/UserMapper.java` - toUserResponse 메서드 추가
- `src/main/java/com/example/soso/users/domain/entity/Gender.java` - NONE 옵션 추가
- `src/main/java/com/example/soso/users/service/SignupService.java` - 반환 타입 변경
- `src/main/java/com/example/soso/users/service/SignupServiceImpl.java` - UserResponse 포함하여 반환
- `src/main/java/com/example/soso/users/controller/SignupController.java` - 응답 타입 변경
- `src/main/java/com/example/soso/kakao/service/KakaoService.java` - 반환 타입 변경
- `src/main/java/com/example/soso/kakao/service/UserLoginService.java` - UserResponse 포함하여 반환
- `src/main/java/com/example/soso/kakao/service/KakaoServiceImpl.java` - KakaoLoginResponse 반환
- `src/main/java/com/example/soso/kakao/controller/KakaoAuthController.java` - 응답 타입 변경

### Test Files
- `src/test/java/com/example/soso/users/controller/SignupControllerTest.java` - 새 응답 구조에 맞게 수정
- `src/test/java/com/example/soso/users/service/SignupServiceTest.java` - 새 응답 구조에 맞게 수정
- `src/test/java/com/example/soso/users/controller/SignupControllerIntegrationTest.java` - 새 응답 구조에 맞게 수정

## ✅ Checklist

- [x] 컴파일 성공
- [x] 빌드 성공
- [x] 단위 테스트 통과
- [x] 로컬 환경 테스트 완료
- [x] Docker 환경 테스트 완료
- [x] Swagger 문서 업데이트
- [x] OpenAPI 스펙 검증
- [x] Orval 호환성 확인
- [x] API 일관성 검증

## 🚀 Benefits

1. **새로운 기능 추가**:
   - 사용자 정보 조회 API (`GET /users/me`) 제공
   - JWT 기반 인증으로 본인 정보 조회 가능

2. **성능 개선**:
   - 회원가입/로그인 후 추가 API 호출 불필요
   - 초기 로딩 시간 단축

3. **사용자 경험 개선**:
   - 회원가입/로그인 후 즉시 사용자 정보 사용 가능
   - 페이지 새로고침 시에도 `/users/me`로 사용자 정보 복구 가능

4. **코드 품질**:
   - 일관된 `UserResponse` 구조 사용 (세 API 모두 동일한 DTO)
   - 명확한 API 역할 구분

5. **타입 안정성**:
   - `gender`, `ageRange` 필드 필수화로 런타임 에러 방지
   - Orval 자동 생성 타입의 정확도 향상
   - `Gender.NONE` 추가로 선택 안함 옵션 제공


## 💬 Additional Notes

- **새로 추가된 API**: `GET /users/me`는 이 브랜치에서 새로 추가된 API입니다.
- **하위 호환성**: 회원가입/로그인 API의 응답 구조가 변경되었으므로, 프론트엔드에서 새로운 응답 구조에 맞게 코드를 수정해야 합니다.
  - `jwtAccessToken` → `accessToken`으로 필드명 변경
  - `user` 필드 추가
- **필수 필드**: `gender`와 `ageRange`를 필수 필드로 변경했으므로, 프론트엔드에서 이 값들이 항상 존재한다고 가정할 수 있습니다.
- **성별 선택**: `Gender.NONE` 추가로 사용자가 성별을 선택하지 않아도 회원가입 가능합니다.
- **카카오 로그인**: `isNewUser` 플래그로 신규/기존 사용자를 명확히 구분할 수 있습니다.
