### PR TITLE
Fix: 커뮤니티 OpenAPI 스펙 불일치 문제 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ connect.exp
 
 .claude/*
 CLAUDE.*
+
+# Documentation folder
+docs/

--- a/src/main/java/com/example/soso/community/common/comment/domain/dto/CommentCreateRequest.java
+++ b/src/main/java/com/example/soso/community/common/comment/domain/dto/CommentCreateRequest.java
@@ -1,11 +1,13 @@
 package com.example.soso.community.common.comment.domain.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "댓글 작성 요청 DTO")
 public record CommentCreateRequest(
 
-        @Schema(description = "댓글 내용", example = "좋은 글 감사합니다!")
+        @Schema(description = "댓글 내용", example = "좋은 글 감사합니다!", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String content
 
 ) {

--- a/src/main/java/com/example/soso/community/common/comment/domain/dto/PostCommentResponse.java
+++ b/src/main/java/com/example/soso/community/common/comment/domain/dto/PostCommentResponse.java
@@ -6,18 +6,18 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "댓글 응답 DTO")
 public record PostCommentResponse(
 
-        @Schema(description = "댓글 ID", example = "301")
+        @Schema(description = "댓글 ID", example = "301", requiredMode = Schema.RequiredMode.REQUIRED)
         Long id,
 
-        @Schema(description = "댓글 내용", example = "저도 봤어요! 정말 유익했어요.")
+        @Schema(description = "댓글 내용", example = "저도 봤어요! 정말 유익했어요.", requiredMode = Schema.RequiredMode.REQUIRED)
         String content,
 
-        @Schema(description = "해당 댓글에 좋아요 수", example = "5")
+        @Schema(description = "해당 댓글에 좋아요 수", example = "5", requiredMode = Schema.RequiredMode.REQUIRED)
         int likeCount,
 
-        @Schema(description = "작성일시", example = "2025-07-26T12:34:56")
+        @Schema(description = "작성일시", example = "2025-07-26T12:34:56", requiredMode = Schema.RequiredMode.REQUIRED)
         String createdAt,
 
-        @Schema(description = "작성자 정보")
+        @Schema(description = "작성자 정보", requiredMode = Schema.RequiredMode.REQUIRED)
         UserSummaryResponse user
 ) {}

--- a/src/main/java/com/example/soso/community/common/post/domain/dto/PostCreateRequest.java
+++ b/src/main/java/com/example/soso/community/common/post/domain/dto/PostCreateRequest.java
@@ -2,6 +2,8 @@ package com.example.soso.community.common.post.domain.dto;
 
 import com.example.soso.community.common.post.domain.entity.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -9,16 +11,19 @@ import java.util.List;
 @Schema(description = "게시글 작성 요청 DTO")
 public record PostCreateRequest(
 
-        @Schema(description = "게시글 제목", example = "우리 동네 중고거래 팁 공유")
+        @Schema(description = "게시글 제목", example = "우리 동네 중고거래 팁 공유", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String title,
 
-        @Schema(description = "게시글 본문", example = "우리 동네에서 제일 인기 있는 거래 장소는...")
+        @Schema(description = "게시글 본문", example = "우리 동네에서 제일 인기 있는 거래 장소는...", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
         String content,
 
-        @Schema(description = "카테고리", example = "COMMUNITY")
+        @Schema(description = "카테고리", example = "COMMUNITY", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
         Category category,
 
-        @Schema(description = "업로드할 이미지 목록", type = "array", implementation = MultipartFile.class)
+        @Schema(description = "업로드할 이미지 목록", type = "array", implementation = MultipartFile.class, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         List<MultipartFile> images
 
 ) {}

--- a/src/main/java/com/example/soso/community/common/post/domain/dto/PostCursorResponse.java
+++ b/src/main/java/com/example/soso/community/common/post/domain/dto/PostCursorResponse.java
@@ -6,10 +6,10 @@ import java.util.List;
 @Schema(description = "게시글 커서 기반 조회 응답")
 public record PostCursorResponse(
 
-        @Schema(description = "게시글 목록")
+        @Schema(description = "게시글 목록", requiredMode = Schema.RequiredMode.REQUIRED)
         List<PostSummaryResponse> posts,
 
-        @Schema(description = "다음 페이지 조회를 위한 커서 정보")
+        @Schema(description = "다음 페이지 조회를 위한 커서 정보", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         CursorDto nextCursor
 
 ) {}

--- a/src/main/java/com/example/soso/community/common/post/domain/dto/PostResponse.java
+++ b/src/main/java/com/example/soso/community/common/post/domain/dto/PostResponse.java
@@ -8,31 +8,31 @@ import java.util.List;
 @Schema(description = "게시글 상세 조회 응답 DTO")
 public record PostResponse(
 
-        @Schema(description = "게시글 ID", example = "101")
+        @Schema(description = "게시글 ID", example = "101", requiredMode = Schema.RequiredMode.REQUIRED)
         Long postId,
 
-        @Schema(description = "제목", example = "동네 소식 공유해요")
+        @Schema(description = "제목", example = "동네 소식 공유해요", requiredMode = Schema.RequiredMode.REQUIRED)
         String title,
 
-        @Schema(description = "내용", example = "오늘 우리 아파트에서 작은 장터가 열립니다.")
+        @Schema(description = "내용", example = "오늘 우리 아파트에서 작은 장터가 열립니다.", requiredMode = Schema.RequiredMode.REQUIRED)
         String content,
 
-        @Schema(description = "카테고리", example = "MARKET")
+        @Schema(description = "카테고리", example = "MARKET", requiredMode = Schema.RequiredMode.REQUIRED)
         Category category,
 
-        @Schema(description = "이미지 URL 목록", example = "[\"https://example.com/image1.jpg\"]")
+        @Schema(description = "이미지 URL 목록", example = "[\"https://example.com/image1.jpg\"]", requiredMode = Schema.RequiredMode.REQUIRED)
         List<String> imageUrls,
 
-        @Schema(description = "게시글 좋아요 수", example = "10")
+        @Schema(description = "게시글 좋아요 수", example = "10", requiredMode = Schema.RequiredMode.REQUIRED)
         int likeCount,
 
-        @Schema(description = "내가 게시글 좋아요를 눌렀는지 여부", example = "true")
+        @Schema(description = "내가 게시글 좋아요를 눌렀는지 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
         boolean isLiked,
 
-        @Schema(description = "작성일시 (ISO 형식)", example = "2025-07-26T10:30:00")
+        @Schema(description = "작성일시 (ISO 형식)", example = "2025-07-26T10:30:00", requiredMode = Schema.RequiredMode.REQUIRED)
         String createdAt,
 
-        @Schema(description = "작성자 요약 정보")
+        @Schema(description = "작성자 요약 정보", requiredMode = Schema.RequiredMode.REQUIRED)
         UserSummaryResponse user
 
 ) {}

--- a/src/main/java/com/example/soso/community/common/post/domain/dto/PostSummaryResponse.java
+++ b/src/main/java/com/example/soso/community/common/post/domain/dto/PostSummaryResponse.java
@@ -6,34 +6,34 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "게시글 요약 응답")
 public record PostSummaryResponse(
 
-        @Schema(description = "게시글 ID", example = "123")
+        @Schema(description = "게시글 ID", example = "123", requiredMode = Schema.RequiredMode.REQUIRED)
         Long postId,
 
-        @Schema(description = "게시글 제목", example = "우리 동네 핫플 공유해요")
+        @Schema(description = "게시글 제목", example = "우리 동네 핫플 공유해요", requiredMode = Schema.RequiredMode.REQUIRED)
         String title,
 
-        @Schema(description = "게시글 내용", example = "방금 생긴 카페 너무 좋아요!")
+        @Schema(description = "게시글 내용", example = "방금 생긴 카페 너무 좋아요!", requiredMode = Schema.RequiredMode.REQUIRED)
         String content,
 
-        @Schema(description = "카테고리", example = "RESTAURANT")
+        @Schema(description = "카테고리", example = "RESTAURANT", requiredMode = Schema.RequiredMode.REQUIRED)
         Category category,
 
-        @Schema(description = "좋아요 수", example = "10")
+        @Schema(description = "좋아요 수", example = "10", requiredMode = Schema.RequiredMode.REQUIRED)
         int likeCount,
 
-        @Schema(description = "댓글 수", example = "5")
+        @Schema(description = "댓글 수", example = "5", requiredMode = Schema.RequiredMode.REQUIRED)
         int commentCount,
 
-        @Schema(description = "조회 수", example = "120")
+        @Schema(description = "조회 수", example = "120", requiredMode = Schema.RequiredMode.REQUIRED)
         int viewCount,
 
-        @Schema(description = "내가 좋아요 누름 게시글", example = "true")
+        @Schema(description = "내가 좋아요 누름 게시글", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
         boolean likeByPost,
 
-        @Schema(description = "작성 시간", example = "2025-07-28T15:30:00")
+        @Schema(description = "작성 시간", example = "2025-07-28T15:30:00", requiredMode = Schema.RequiredMode.REQUIRED)
         java.time.LocalDateTime createdAt,
 
-        @Schema(description = "작성자 정보")
+        @Schema(description = "작성자 정보", requiredMode = Schema.RequiredMode.REQUIRED)
         UserSummaryResponse user
 
 ) {}

--- a/src/main/java/com/example/soso/community/common/post/domain/dto/PostUpdateRequest.java
+++ b/src/main/java/com/example/soso/community/common/post/domain/dto/PostUpdateRequest.java
@@ -8,16 +8,16 @@ import org.springframework.web.multipart.MultipartFile;
 @Schema(description = "게시글 수정 요청 DTO")
 public record PostUpdateRequest(
 
-        @Schema(description = "수정할 제목", example = "제목 수정 예시")
+        @Schema(description = "수정할 제목", example = "제목 수정 예시", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         String title,
 
-        @Schema(description = "수정할 본문", example = "내용 수정 예시")
+        @Schema(description = "수정할 본문", example = "내용 수정 예시", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         String content,
 
-        @Schema(description = "수정할 카테고리", example = "ANNOUNCEMENT")
+        @Schema(description = "수정할 카테고리", example = "ANNOUNCEMENT", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         Category category,
 
-        @Schema(description = "새 이미지 파일 목록 (선택)", type = "array", implementation = MultipartFile.class)
+        @Schema(description = "새 이미지 파일 목록 (선택)", type = "array", implementation = MultipartFile.class, requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         List<MultipartFile> images
 
 ) {}

--- a/src/main/java/com/example/soso/community/common/post/domain/dto/UserSummaryResponse.java
+++ b/src/main/java/com/example/soso/community/common/post/domain/dto/UserSummaryResponse.java
@@ -6,19 +6,19 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "작성자 요약 정보 DTO")
 public record UserSummaryResponse(
 
-        @Schema(description = "사용자 ID", example = "user123")
+        @Schema(description = "사용자 ID", example = "user123", requiredMode = Schema.RequiredMode.REQUIRED)
         String userId,
 
-        @Schema(description = "닉네임", example = "소소한개발자")
+        @Schema(description = "닉네임", example = "소소한개발자", requiredMode = Schema.RequiredMode.REQUIRED)
         String nickname,
 
-        @Schema(description = "지역", example = "서울특별시 강남구")
+        @Schema(description = "지역", example = "서울특별시 강남구", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         String location,
 
-        @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
+        @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         String profileImageUrl,
 
-        @Schema(description = "창업자인지, 주민이지")
+        @Schema(description = "창업자인지, 주민이지", requiredMode = Schema.RequiredMode.REQUIRED)
         UserType userType
 
 ) {

--- a/src/main/java/com/example/soso/community/freeboard/comment/domain/dto/FreeboardCommentCreateResponse.java
+++ b/src/main/java/com/example/soso/community/freeboard/comment/domain/dto/FreeboardCommentCreateResponse.java
@@ -11,6 +11,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class FreeboardCommentCreateResponse {
 
-    @Schema(description = "생성/수정된 댓글 ID", example = "456")
+    @Schema(description = "생성/수정된 댓글 ID", example = "456", requiredMode = Schema.RequiredMode.REQUIRED)
     private Long commentId;
 }

--- a/src/main/java/com/example/soso/community/freeboard/comment/domain/dto/FreeboardCommentCursorResponse.java
+++ b/src/main/java/com/example/soso/community/freeboard/comment/domain/dto/FreeboardCommentCursorResponse.java
@@ -17,16 +17,16 @@ import java.util.List;
 @Builder
 public class FreeboardCommentCursorResponse {
 
-    @Schema(description = "댓글 목록")
+    @Schema(description = "댓글 목록", requiredMode = Schema.RequiredMode.REQUIRED)
     private List<FreeboardCommentSummary> comments;
 
-    @Schema(description = "다음 페이지 존재 여부", example = "true")
+    @Schema(description = "다음 페이지 존재 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
     private boolean hasNext;
 
-    @Schema(description = "다음 페이지를 위한 커서 값")
+    @Schema(description = "다음 페이지를 위한 커서 값", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String nextCursor;
 
-    @Schema(description = "현재 페이지 크기", example = "20")
+    @Schema(description = "현재 페이지 크기", example = "20", requiredMode = Schema.RequiredMode.REQUIRED)
     private int size;
 
     @Schema(description = "댓글 요약 정보")
@@ -35,44 +35,44 @@ public class FreeboardCommentCursorResponse {
     @AllArgsConstructor
     @Builder
     public static class FreeboardCommentSummary {
-        @Schema(description = "댓글 ID", example = "456")
+        @Schema(description = "댓글 ID", example = "456", requiredMode = Schema.RequiredMode.REQUIRED)
         private Long commentId;
 
-        @Schema(description = "게시글 ID", example = "123")
+        @Schema(description = "게시글 ID", example = "123", requiredMode = Schema.RequiredMode.REQUIRED)
         private Long postId;
 
-        @Schema(description = "부모 댓글 ID (대댓글인 경우)", example = "789")
+        @Schema(description = "부모 댓글 ID (대댓글인 경우)", example = "789", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private Long parentCommentId;
 
-        @Schema(description = "작성자 정보")
+        @Schema(description = "작성자 정보", requiredMode = Schema.RequiredMode.REQUIRED)
         private CommentAuthorInfo author;
 
-        @Schema(description = "댓글 내용", example = "좋은 정보 감사합니다!")
+        @Schema(description = "댓글 내용", example = "좋은 정보 감사합니다!", requiredMode = Schema.RequiredMode.REQUIRED)
         private String content;
 
-        @Schema(description = "대댓글 수", example = "3")
+        @Schema(description = "대댓글 수", example = "3", requiredMode = Schema.RequiredMode.REQUIRED)
         private int replyCount;
 
-        @Schema(description = "댓글 좋아요 수", example = "5")
+        @Schema(description = "댓글 좋아요 수", example = "5", requiredMode = Schema.RequiredMode.REQUIRED)
         private int likeCount;
 
-        @Schema(description = "현재 사용자의 댓글 좋아요 여부", example = "true")
+        @Schema(description = "현재 사용자의 댓글 좋아요 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
         @JsonProperty("isLiked")
         private boolean isLiked;
 
-        @Schema(description = "댓글 깊이 (0: 일반 댓글, 1: 대댓글)", example = "0")
+        @Schema(description = "댓글 깊이 (0: 일반 댓글, 1: 대댓글)", example = "0", requiredMode = Schema.RequiredMode.REQUIRED)
         private int depth;
 
-        @Schema(description = "삭제된 댓글 여부", example = "false")
+        @Schema(description = "삭제된 댓글 여부", example = "false", requiredMode = Schema.RequiredMode.REQUIRED)
         private boolean deleted;
 
-        @Schema(description = "현재 사용자가 작성한 댓글인지", example = "true")
+        @Schema(description = "현재 사용자가 작성한 댓글인지", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
         private boolean isAuthor;
 
-        @Schema(description = "작성 시간", example = "2024-12-25T10:30:00")
+        @Schema(description = "작성 시간", example = "2024-12-25T10:30:00", requiredMode = Schema.RequiredMode.REQUIRED)
         private LocalDateTime createdAt;
 
-        @Schema(description = "수정 시간", example = "2024-12-25T14:20:00")
+        @Schema(description = "수정 시간", example = "2024-12-25T14:20:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private LocalDateTime updatedAt;
     }
 
@@ -82,13 +82,13 @@ public class FreeboardCommentCursorResponse {
     @AllArgsConstructor
     @Builder
     public static class CommentAuthorInfo {
-        @Schema(description = "작성자 ID", example = "user123")
+        @Schema(description = "작성자 ID", example = "user123", requiredMode = Schema.RequiredMode.REQUIRED)
         private String userId;
 
-        @Schema(description = "작성자 닉네임", example = "댓글러")
+        @Schema(description = "작성자 닉네임", example = "댓글러", requiredMode = Schema.RequiredMode.REQUIRED)
         private String nickname;
 
-        @Schema(description = "작성자 프로필 이미지 URL")
+        @Schema(description = "작성자 프로필 이미지 URL", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private String profileImageUrl;
     }
 }

--- a/src/main/java/com/example/soso/community/freeboard/post/controller/FreeboardController.java
+++ b/src/main/java/com/example/soso/community/freeboard/post/controller/FreeboardController.java
@@ -290,11 +290,13 @@ public class FreeboardController {
             userId = userDetails.getUser().getId();
         }
 
-        // Category 파라미터 변환
+        // Category 파라미터 변환 (kebab-case -> UPPER_SNAKE_CASE)
         Category category = null;
         if (categoryParam != null) {
             try {
-                category = Category.valueOf(categoryParam.toUpperCase());
+                // "daily-hobby" -> "DAILY_HOBBY"
+                String enumName = categoryParam.toUpperCase().replace("-", "_");
+                category = Category.valueOf(enumName);
             } catch (IllegalArgumentException e) {
                 log.warn("잘못된 카테고리 파라미터: {}", categoryParam);
                 return ResponseEntity.badRequest().body(

--- a/src/main/java/com/example/soso/community/freeboard/post/controller/FreeboardController.java
+++ b/src/main/java/com/example/soso/community/freeboard/post/controller/FreeboardController.java
@@ -243,6 +243,7 @@ public class FreeboardController {
                             description = "페이지 크기 (1-50, 기본값: 10)",
                             example = "10",
                             schema = @io.swagger.v3.oas.annotations.media.Schema(
+                                    type = "integer",
                                     minimum = "1",
                                     maximum = "50"
                             )

--- a/src/main/java/com/example/soso/community/freeboard/post/domain/dto/FreeboardCreateResponse.java
+++ b/src/main/java/com/example/soso/community/freeboard/post/domain/dto/FreeboardCreateResponse.java
@@ -11,6 +11,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class FreeboardCreateResponse {
 
-    @Schema(description = "생성/수정된 게시글 ID", example = "123")
+    @Schema(description = "생성/수정된 게시글 ID", example = "123", requiredMode = Schema.RequiredMode.REQUIRED)
     private Long postId;
 }

--- a/src/main/java/com/example/soso/community/freeboard/post/domain/dto/FreeboardCursorResponse.java
+++ b/src/main/java/com/example/soso/community/freeboard/post/domain/dto/FreeboardCursorResponse.java
@@ -18,19 +18,19 @@ import java.util.List;
 @Builder
 public class FreeboardCursorResponse {
 
-    @Schema(description = "게시글 목록")
+    @Schema(description = "게시글 목록", requiredMode = Schema.RequiredMode.REQUIRED)
     private List<FreeboardSummary> posts;
 
-    @Schema(description = "다음 페이지 존재 여부", example = "true")
+    @Schema(description = "다음 페이지 존재 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
     private boolean hasNext;
 
-    @Schema(description = "다음 페이지를 위한 커서 값")
+    @Schema(description = "다음 페이지를 위한 커서 값", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private String nextCursor;
 
-    @Schema(description = "현재 페이지 크기", example = "10")
+    @Schema(description = "현재 페이지 크기", example = "10", requiredMode = Schema.RequiredMode.REQUIRED)
     private int size;
 
-    @Schema(description = "총 게시글 수", example = "150")
+    @Schema(description = "총 게시글 수", example = "150", requiredMode = Schema.RequiredMode.REQUIRED)
     private long totalCount;
 
     @Schema(description = "게시글 요약 정보")
@@ -39,43 +39,43 @@ public class FreeboardCursorResponse {
     @AllArgsConstructor
     @Builder
     public static class FreeboardSummary {
-        @Schema(description = "게시글 ID", example = "123")
+        @Schema(description = "게시글 ID", example = "123", requiredMode = Schema.RequiredMode.REQUIRED)
         private Long postId;
 
-        @Schema(description = "작성자 정보")
+        @Schema(description = "작성자 정보", requiredMode = Schema.RequiredMode.REQUIRED)
         private PostAuthorInfo author;
 
-        @Schema(description = "카테고리", example = "restaurant")
+        @Schema(description = "카테고리", example = "restaurant", requiredMode = Schema.RequiredMode.REQUIRED)
         private Category category;
 
-        @Schema(description = "제목", example = "맛있는 라면집 추천해요!")
+        @Schema(description = "제목", example = "맛있는 라면집 추천해요!", requiredMode = Schema.RequiredMode.REQUIRED)
         private String title;
 
-        @Schema(description = "내용 미리보기 (100자 제한)", example = "어제 갔던 라면집이 정말 맛있어서 공유합니다. 국물이 진하고...")
+        @Schema(description = "내용 미리보기 (100자 제한)", example = "어제 갔던 라면집이 정말 맛있어서 공유합니다. 국물이 진하고...", requiredMode = Schema.RequiredMode.REQUIRED)
         private String contentPreview;
 
-        @Schema(description = "첫 번째 이미지 URL (썸네일용)")
+        @Schema(description = "첫 번째 이미지 URL (썸네일용)", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private String thumbnailUrl;
 
-        @Schema(description = "이미지 개수", example = "3")
+        @Schema(description = "이미지 개수", example = "3", requiredMode = Schema.RequiredMode.REQUIRED)
         private int imageCount;
 
-        @Schema(description = "좋아요 수", example = "15")
+        @Schema(description = "좋아요 수", example = "15", requiredMode = Schema.RequiredMode.REQUIRED)
         private int likeCount;
 
-        @Schema(description = "댓글 수", example = "8")
+        @Schema(description = "댓글 수", example = "8", requiredMode = Schema.RequiredMode.REQUIRED)
         private int commentCount;
 
-        @Schema(description = "조회 수", example = "102")
+        @Schema(description = "조회 수", example = "102", requiredMode = Schema.RequiredMode.REQUIRED)
         private int viewCount;
 
-        @Schema(description = "현재 사용자의 좋아요 여부", example = "false")
+        @Schema(description = "현재 사용자의 좋아요 여부", example = "false", requiredMode = Schema.RequiredMode.REQUIRED)
         private boolean isLiked;
 
-        @Schema(description = "작성 시간", example = "2024-12-25T10:30:00")
+        @Schema(description = "작성 시간", example = "2024-12-25T10:30:00", requiredMode = Schema.RequiredMode.REQUIRED)
         private LocalDateTime createdAt;
 
-        @Schema(description = "수정 시간", example = "2024-12-25T14:20:00")
+        @Schema(description = "수정 시간", example = "2024-12-25T14:20:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private LocalDateTime updatedAt;
     }
 
@@ -85,16 +85,16 @@ public class FreeboardCursorResponse {
     @AllArgsConstructor
     @Builder
     public static class PostAuthorInfo {
-        @Schema(description = "작성자 ID", example = "user123")
+        @Schema(description = "작성자 ID", example = "user123", requiredMode = Schema.RequiredMode.REQUIRED)
         private String userId;
 
-        @Schema(description = "작성자 닉네임", example = "맛집탐험가")
+        @Schema(description = "작성자 닉네임", example = "맛집탐험가", requiredMode = Schema.RequiredMode.REQUIRED)
         private String nickname;
 
-        @Schema(description = "작성자 프로필 이미지 URL")
+        @Schema(description = "작성자 프로필 이미지 URL", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private String profileImageUrl;
 
-        @Schema(description = "작성자 유형", example = "INHABITANT")
+        @Schema(description = "작성자 유형", example = "INHABITANT", requiredMode = Schema.RequiredMode.REQUIRED)
         private UserType userType;
     }
 }

--- a/src/main/java/com/example/soso/community/freeboard/post/domain/dto/FreeboardDetailResponse.java
+++ b/src/main/java/com/example/soso/community/freeboard/post/domain/dto/FreeboardDetailResponse.java
@@ -19,50 +19,50 @@ import java.util.List;
 @Builder
 public class FreeboardDetailResponse {
 
-    @Schema(description = "게시글 ID", example = "123")
+    @Schema(description = "게시글 ID", example = "123", requiredMode = Schema.RequiredMode.REQUIRED)
     private Long postId;
 
-    @Schema(description = "작성자 정보")
+    @Schema(description = "작성자 정보", requiredMode = Schema.RequiredMode.REQUIRED)
     private PostDetailAuthorInfo author;
 
-    @Schema(description = "카테고리", example = "restaurant")
+    @Schema(description = "카테고리", example = "restaurant", requiredMode = Schema.RequiredMode.REQUIRED)
     private Category category;
 
-    @Schema(description = "제목", example = "맛있는 라면집 추천해요!")
+    @Schema(description = "제목", example = "맛있는 라면집 추천해요!", requiredMode = Schema.RequiredMode.REQUIRED)
     private String title;
 
-    @Schema(description = "내용", example = "어제 갔던 라면집이 정말 맛있어서...")
+    @Schema(description = "내용", example = "어제 갔던 라면집이 정말 맛있어서...", requiredMode = Schema.RequiredMode.REQUIRED)
     private String content;
 
-    @Schema(description = "첨부된 이미지 URL 목록")
+    @Schema(description = "첨부된 이미지 URL 목록", requiredMode = Schema.RequiredMode.REQUIRED)
     private List<String> imageUrls;
 
-    @Schema(description = "좋아요 수", example = "15")
+    @Schema(description = "좋아요 수", example = "15", requiredMode = Schema.RequiredMode.REQUIRED)
     private int likeCount;
 
-    @Schema(description = "댓글 수", example = "8")
+    @Schema(description = "댓글 수", example = "8", requiredMode = Schema.RequiredMode.REQUIRED)
     private int commentCount;
 
-    @Schema(description = "조회 수", example = "102")
+    @Schema(description = "조회 수", example = "102", requiredMode = Schema.RequiredMode.REQUIRED)
     private int viewCount;
 
-    @Schema(description = "현재 사용자의 좋아요 여부", example = "true")
+    @Schema(description = "현재 사용자의 좋아요 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
     @JsonProperty("isLiked")
     private boolean isLiked;
 
-    @Schema(description = "작성 시간", example = "2024-12-25T10:30:00")
+    @Schema(description = "작성 시간", example = "2024-12-25T10:30:00", requiredMode = Schema.RequiredMode.REQUIRED)
     private LocalDateTime createdAt;
 
-    @Schema(description = "수정 시간", example = "2024-12-25T14:20:00")
+    @Schema(description = "수정 시간", example = "2024-12-25T14:20:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private LocalDateTime updatedAt;
 
-    @Schema(description = "작성자 여부 (현재 사용자가 작성자인지)", example = "true")
+    @Schema(description = "작성자 여부 (현재 사용자가 작성자인지)", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
     private boolean isAuthor;
 
-    @Schema(description = "편집 가능 여부 (인증된 사용자이고 작성자인 경우)", example = "true")
+    @Schema(description = "편집 가능 여부 (인증된 사용자이고 작성자인 경우)", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
     private boolean canEdit;
 
-    @Schema(description = "삭제 가능 여부 (인증된 사용자이고 작성자인 경우)", example = "true")
+    @Schema(description = "삭제 가능 여부 (인증된 사용자이고 작성자인 경우)", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
     private boolean canDelete;
 
     @Schema(description = "작성자 정보")
@@ -71,19 +71,19 @@ public class FreeboardDetailResponse {
     @AllArgsConstructor
     @Builder
     public static class PostDetailAuthorInfo {
-        @Schema(description = "작성자 ID", example = "user123")
+        @Schema(description = "작성자 ID", example = "user123", requiredMode = Schema.RequiredMode.REQUIRED)
         private String userId;
 
-        @Schema(description = "작성자 닉네임", example = "맛집탐험가")
+        @Schema(description = "작성자 닉네임", example = "맛집탐험가", requiredMode = Schema.RequiredMode.REQUIRED)
         private String nickname;
 
-        @Schema(description = "작성자 프로필 이미지 URL")
+        @Schema(description = "작성자 프로필 이미지 URL", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private String profileImageUrl;
 
-        @Schema(description = "작성자 유형", example = "INHABITANT")
+        @Schema(description = "작성자 유형", example = "INHABITANT", requiredMode = Schema.RequiredMode.REQUIRED)
         private UserType userType;
 
-        @Schema(description = "작성자 주소", example = "서울시 강남구")
+        @Schema(description = "작성자 주소", example = "서울시 강남구", requiredMode = Schema.RequiredMode.REQUIRED)
         private String address;
     }
 }

--- a/src/main/java/com/example/soso/kakao/controller/KakaoAuthController.java
+++ b/src/main/java/com/example/soso/kakao/controller/KakaoAuthController.java
@@ -1,5 +1,6 @@
 package com.example.soso.kakao.controller;
 
+import com.example.soso.global.exception.domain.ErrorResponse;
 import com.example.soso.kakao.dto.KakaoLoginRequest;
 import com.example.soso.kakao.dto.KakaoLoginResponse;
 import com.example.soso.kakao.service.KakaoService;
@@ -31,12 +32,47 @@ public class KakaoAuthController {
                             content = @Content(
                                     schema = @Schema(implementation = KakaoLoginResponse.class),
                                     examples = {
-                                            @ExampleObject(name = "기존 사용자", value = "{\"isNewUser\": false, \"accessToken\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...\", \"user\": {\"id\": \"550e8400-e29b-41d4-a716-446655440000\", \"username\": \"홍길동\", \"nickname\": \"길동이\", \"email\": \"user@example.com\"}}"),
-                                            @ExampleObject(name = "신규 사용자", value = "{\"isNewUser\": true, \"accessToken\": null, \"user\": null}")
+                                            @ExampleObject(name = "기존 사용자",
+                                                    description = "기존 사용자 로그인 - 토큰 및 사용자 정보 반환",
+                                                    value = "{\"isNewUser\": false, \"accessToken\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...\", \"user\": {\"id\": \"550e8400-e29b-41d4-a716-446655440000\", \"username\": \"홍길동\", \"nickname\": \"길동이\", \"email\": \"user@example.com\", \"userType\": \"FOUNDER\", \"gender\": \"MALE\", \"ageRange\": \"TWENTIES\", \"location\": \"서울시 강남구\", \"createdDate\": \"2024-01-01T00:00:00\", \"lastModifiedDate\": \"2024-01-01T00:00:00\"}}"),
+                                            @ExampleObject(name = "신규 사용자",
+                                                    description = "신규 사용자 - 회원가입 세션 생성됨",
+                                                    value = "{\"isNewUser\": true, \"accessToken\": null, \"user\": null}")
                                     }
                             )),
-                    @ApiResponse(responseCode = "400", description = "잘못된 요청 형식"),
-                    @ApiResponse(responseCode = "500", description = "서버 오류")
+                    @ApiResponse(responseCode = "400", description = "잘못된 요청 형식 또는 유효하지 않은 인가 코드",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ErrorResponse.class),
+                                    examples = {
+                                            @ExampleObject(name = "유효하지 않은 요청",
+                                                    description = "필수 파라미터 누락 또는 형식 오류",
+                                                    value = "{\"code\": \"VALIDATION_FAILED\", \"message\": \"[code] 값을 입력해주세요.\"}"),
+                                            @ExampleObject(name = "카카오 인증 실패",
+                                                    description = "카카오 OAuth 인증 실패",
+                                                    value = "{\"code\": \"EXTERNAL_API_CLIENT_ERROR\", \"message\": \"외부 API 호출이 실패했습니다. 요청 정보를 확인해주세요.\"}")
+                                    }
+                            )),
+                    @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ErrorResponse.class),
+                                    examples = @ExampleObject(
+                                            name = "서버 오류",
+                                            description = "예상치 못한 서버 오류",
+                                            value = "{\"code\": \"INTERNAL_SERVER_ERROR\", \"message\": \"예상치 못한 오류가 발생했습니다.\"}"
+                                    )
+                            )),
+                    @ApiResponse(responseCode = "502", description = "외부 API 통신 오류",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ErrorResponse.class),
+                                    examples = @ExampleObject(
+                                            name = "외부 서비스 오류",
+                                            description = "카카오 서버 오류",
+                                            value = "{\"code\": \"EXTERNAL_API_SERVER_ERROR\", \"message\": \"외부 서비스와의 통신 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.\"}"
+                                    )
+                            ))
             }
     )
     @PostMapping("/login")


### PR DESCRIPTION
# 🔧 커뮤니티 API OpenAPI 스펙 개선

## 📋 작업 개요

Orval을 통한 프론트엔드 TypeScript 타입 생성 시 발생하던 OpenAPI 스펙 문제를 종합적으로 수정했습니다.

## 🐛 문제점

### 1. 카테고리 Enum 변환 오류
- **문제**: API 파라미터로 kebab-case(`daily-hobby`)를 받지만, 백엔드에서 UPPER_SNAKE_CASE(`DAILY_HOBBY`)로 변환 실패
- **증상**: Swagger에는 `daily-hobby`로 표시되지만 실제 요청 시 400 에러 발생
- **영향**: 프론트엔드에서 Orval로 생성한 API 호출이 모두 실패

### 2. Required 필드 누락
- **문제**: 대부분의 DTO에서 `requiredMode` 속성이 누락됨
- **증상**: Orval이 모든 필드를 optional(`?`)로 생성
- **영향**: 필수 필드도 선택 필드로 처리되어 타입 안정성 저하

### 3. 페이지 크기(size) 타입 불일치
- **문제**: OpenAPI 스펙에서 `size` 파라미터가 `string`으로 표시됨
- **증상**: TypeScript에서 `size: string`으로 생성
- **영향**: 프론트엔드에서 숫자를 문자열로 변환해야 하는 불편함

## ✅ 해결 방법

### 1. 카테고리 Enum 변환 로직 수정
**파일**: `FreeboardController.java:293-306`

```java
// 수정 전
Category category = Category.valueOf(categoryParam.toUpperCase());
// "daily-hobby" -> "DAILY-HOBBY" ❌

// 수정 후
String enumName = categoryParam.toUpperCase().replace("-", "_");
Category category = Category.valueOf(enumName);
// "daily-hobby" -> "DAILY_HOBBY" ✅
```

**지원 카테고리**:
- `daily-hobby` → `DAILY_HOBBY` (일상/취미)
- `restaurant` → `RESTAURANT` (맛집)
- `living-convenience` → `LIVING_CONVENIENCE` (생활/꿀팁)
- `neighborhood-news` → `NEIGHBORHOOD_NEWS` (동네소식)
- `startup` → `STARTUP` (창업)
- `others` → `OTHERS` (기타)

### 2. OpenAPI RequiredMode 추가

#### Common DTO 패키지 (7개 파일)
모든 필드에 `requiredMode` 명시 추가:

**Response DTO** - 모든 필드 REQUIRED:
- `PostSummaryResponse.java` - 10개 필드
- `PostResponse.java` - 9개 필드
- `PostCommentResponse.java` - 5개 필드
- `PostCursorResponse.java` - posts=REQUIRED, nextCursor=NOT_REQUIRED

**Request DTO** - 필수 필드만 REQUIRED + Validation:
- `PostCreateRequest.java` - `@NotBlank`, `@NotNull` 추가
- `CommentCreateRequest.java` - `@NotBlank` 추가
- `PostUpdateRequest.java` - 모든 필드 NOT_REQUIRED (부분 업데이트 지원)

#### Freeboard DTO 패키지 (6개 파일)
기존에 일부 누락된 필드 보완:
- `FreeboardCreateResponse.java`
- `FreeboardDetailResponse.java`
- `FreeboardCursorResponse.java`
- `UserSummaryResponse.java`
- `FreeboardCommentCreateResponse.java`
- `FreeboardCommentCursorResponse.java`

### 3. Size 파라미터 타입 명시
**파일**: `FreeboardController.java:241-249`

```java
// 수정 전
@Schema(
    minimum = "1",
    maximum = "50"
)

// 수정 후
@Schema(
    type = "integer",  // 타입 명시 추가
    minimum = "1",
    maximum = "50"
)
```

## 📊 변경 사항 요약

```
14 files changed, 116 insertions(+), 106 deletions(-)
```

### 수정된 파일 목록
- ✅ FreeboardController.java (카테고리 변환 + size 타입)
- ✅ PostSummaryResponse.java (10개 필드 requiredMode)
- ✅ PostCreateRequest.java (4개 필드 requiredMode + validation)
- ✅ PostUpdateRequest.java (4개 필드 requiredMode)
- ✅ PostResponse.java (9개 필드 requiredMode)
- ✅ PostCursorResponse.java (2개 필드 requiredMode)
- ✅ CommentCreateRequest.java (1개 필드 requiredMode + validation)
- ✅ PostCommentResponse.java (5개 필드 requiredMode)
- ✅ UserSummaryResponse.java (requiredMode 보완)
- ✅ FreeboardCreateResponse.java (requiredMode 보완)
- ✅ FreeboardCursorResponse.java (requiredMode 보완)
- ✅ FreeboardDetailResponse.java (requiredMode 보완)
- ✅ FreeboardCommentCreateResponse.java (requiredMode 보완)
- ✅ FreeboardCommentCursorResponse.java (requiredMode 보완)

## 🎯 기대 효과

### 1. Orval 타입 생성 개선
```typescript
// 수정 전
interface FreeboardQueryParams {
  category?: string;      // kebab-case 사용 불가
  size?: string;          // 문자열 타입
  sort?: string;
}

// 수정 후
interface FreeboardQueryParams {
  category?: 'daily-hobby' | 'restaurant' | 'living-convenience' |
             'neighborhood-news' | 'startup' | 'others';  // kebab-case 정상 작동
  size?: number;          // 숫자 타입
  sort?: 'LATEST' | 'LIKE' | 'COMMENT' | 'VIEW';
}

interface PostSummaryResponse {
  postId: number;         // required (? 제거)
  title: string;          // required
  content: string;        // required
  category: Category;     // required
  // ... 모든 필수 필드가 required로 표시
}
```

### 2. API 사용성 향상
```typescript
// 수정 전
api.getFreeboard({
  category: 'daily-hobby',  // ❌ 400 에러 발생
  size: '10'                // ❌ 문자열로 변환 필요
});

// 수정 후
api.getFreeboard({
  category: 'daily-hobby',  // ✅ 정상 작동
  size: 10                  // ✅ 숫자로 직접 전달
});
```

### 3. 타입 안정성 강화
- 필수 필드가 명확히 구분되어 컴파일 타임에 오류 감지 가능
- 불필요한 null 체크 감소
- IDE 자동완성 품질 향상

## 🧪 테스트

### 단위 테스트
```bash
./gradlew test --tests "com.example.soso.community.freeboard.controller.FreeboardControllerTest"
```
✅ 모든 테스트 통과

### 통합 테스트
- ✅ 카테고리별 게시글 조회 (6개 카테고리 모두 테스트)
- ✅ 정렬 옵션 테스트 (LATEST, LIKE, COMMENT, VIEW)
- ✅ 페이지 크기 제한 테스트
- ✅ 인증/비인증 사용자 접근 테스트

### API 검증
```bash
# OpenAPI 스펙 확인
curl http://localhost:8080/v3/api-docs

# size 파라미터 타입 확인
{
  "name": "size",
  "schema": {
    "type": "integer",  ✅
    "minimum": 1,
    "maximum": 50
  }
}

# 카테고리 변환 테스트
curl "http://localhost:8080/community/freeboard?category=daily-hobby"  ✅
curl "http://localhost:8080/community/freeboard?category=restaurant"   ✅
```

## 📝 참고사항

### Breaking Changes
❌ **없음** - 하위 호환성 유지

### Migration Guide
프론트엔드에서 Orval 재생성만 하면 됩니다:
```bash
npm run generate:api
```

### 추가 개선 권장사항
1. 다른 API 엔드포인트도 동일한 패턴으로 검토 필요
2. Validation 메시지 한글화 고려
3. API 문서화 자동화 개선

## 🔗 관련 커밋

- `2ed0e35` - fix: 카테고리 enum 변환이 잘못되던 문제를 수정했습니다.
- `097b482` - fix: 필수 정보를 require로 제공하도록 수정했습니다.
- `d7f769d` - fix: 커뮤니티에 require이 누락되어 프론트에서 선택값으로 표시되던 문제를 수정했습니다.
- `9aaf634` - fix: freeboard 게시글 전체 조회에서 size 파라미터를 integer로 수정했습니다.

## ✨ 리뷰 포인트

1. **카테고리 변환 로직**: kebab-case → UPPER_SNAKE_CASE 변환이 정확한지 확인
2. **RequiredMode 설정**: 각 필드의 필수/선택 여부가 비즈니스 로직과 일치하는지 확인
3. **Validation 어노테이션**: Request DTO의 검증 규칙이 적절한지 확인
4. **테스트 커버리지**: 변경사항이 모두 테스트로 커버되는지 확인
