### PR TITLE
Fix: 게시글 및 댓글 상세 조회 로직 개선

### DIFF
--- a/src/main/java/com/example/soso/community/common/post/domain/dto/PostSummaryResponse.java
+++ b/src/main/java/com/example/soso/community/common/post/domain/dto/PostSummaryResponse.java
@@ -27,8 +27,13 @@ public record PostSummaryResponse(
         @Schema(description = "조회 수", example = "120", requiredMode = Schema.RequiredMode.REQUIRED)
         int viewCount,
 
-        @Schema(description = "내가 좋아요 누름 게시글", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
-        boolean likeByPost,
+        @Schema(
+            description = "내가 좋아요 누른 게시글 여부 (비인증 사용자인 경우 null)",
+            example = "true",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            nullable = true
+        )
+        Boolean likeByPost,
 
         @Schema(description = "작성 시간", example = "2025-07-28T15:30:00", requiredMode = Schema.RequiredMode.REQUIRED)
         java.time.LocalDateTime createdAt,

--- a/src/main/java/com/example/soso/community/common/post/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/example/soso/community/common/post/repository/PostRepositoryImpl.java
@@ -50,7 +50,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         OrderSpecifier<?>[] order = postCursorOrder.build(post, sort);
 
         // PostSummaryResponse 생성자 순서: postId, title, content, category, likeCount, commentCount, viewCount, likeByPost, createdAt, user
-        // userId가 null인 경우 좋아요 정보 없이 조회
+        // userId가 null인 경우 좋아요 정보 없이 조회 (null 반환)
         if (userId == null) {
             return queryFactory
                     .select(Projections.constructor(PostSummaryResponse.class,
@@ -61,7 +61,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                             post.likeCount, // int likeCount
                             post.commentCount, // int commentCount
                             post.viewCount, // int viewCount
-                            com.querydsl.core.types.dsl.Expressions.constant(false), // boolean likeByPost
+                            com.querydsl.core.types.dsl.Expressions.nullExpression(Boolean.class), // Boolean likeByPost = null
                             post.createdDate, // LocalDateTime createdAt
                             Projections.constructor(com.example.soso.community.common.post.domain.dto.UserSummaryResponse.class,
                                     user.id,

--- a/src/main/java/com/example/soso/community/freeboard/comment/controller/FreeboardCommentController.java
+++ b/src/main/java/com/example/soso/community/freeboard/comment/controller/FreeboardCommentController.java
@@ -118,7 +118,20 @@ public class FreeboardCommentController {
                     **특징:**
                     - 계층 구조 지원 (부모 댓글 → 대댓글)
                     - 삭제된 댓글은 "삭제된 댓글입니다" 표시
-                    - 작성자 정보 포함
+                    - 총 댓글 수 제공 (total)
+                    - 인증/비인증 사용자 모두 조회 가능
+
+                    **인증 사용자:**
+                    - isAuthorized: true
+                    - isLiked: boolean (좋아요 상태)
+                    - canEdit: boolean (수정 권한)
+                    - canDelete: boolean (삭제 권한)
+
+                    **비인증 사용자:**
+                    - isAuthorized: false
+                    - isLiked: null
+                    - canEdit: null
+                    - canDelete: null
                     """,
             parameters = {
                     @Parameter(
@@ -144,9 +157,16 @@ public class FreeboardCommentController {
                     description = "조회 성공",
                     content = @Content(
                             schema = @Schema(implementation = FreeboardCommentCursorResponse.class),
-                            examples = @ExampleObject(
-                                    value = "{\"comments\":[{\"commentId\":456,\"postId\":123,\"parentCommentId\":null,\"author\":{\"userId\":\"commenter1\",\"nickname\":\"댓글러\",\"profileImageUrl\":\"https://cdn.example.com/user.jpg\"},\"content\":\"첫 댓글입니다.\",\"replyCount\":0,\"likeCount\":0,\"isLiked\":false,\"depth\":0,\"deleted\":false,\"isAuthor\":false,\"createdAt\":\"2025-01-01T10:10:00\",\"updatedAt\":\"2025-01-01T10:10:00\"}],\"hasNext\":false,\"nextCursor\":null,\"size\":1}"
-                            )
+                            examples = {
+                                    @ExampleObject(
+                                            name = "인증 사용자 (본인 댓글 포함)",
+                                            value = "{\"comments\":[{\"commentId\":456,\"postId\":123,\"parentCommentId\":null,\"author\":{\"userId\":\"commenter1\",\"nickname\":\"댓글러\",\"profileImageUrl\":\"https://cdn.example.com/user.jpg\",\"userType\":\"INHABITANT\"},\"content\":\"첫 댓글입니다.\",\"replyCount\":2,\"likeCount\":5,\"depth\":0,\"deleted\":false,\"isAuthor\":true,\"isLiked\":false,\"canEdit\":true,\"canDelete\":true,\"createdAt\":\"2025-01-01T10:10:00\",\"updatedAt\":\"2025-01-01T10:10:00\"}],\"hasNext\":true,\"nextCursor\":\"eyJpZCI6NDU2fQ==\",\"size\":1,\"total\":50,\"isAuthorized\":true}"
+                                    ),
+                                    @ExampleObject(
+                                            name = "비인증 사용자",
+                                            value = "{\"comments\":[{\"commentId\":456,\"postId\":123,\"parentCommentId\":null,\"author\":{\"userId\":\"commenter1\",\"nickname\":\"댓글러\",\"profileImageUrl\":\"https://cdn.example.com/user.jpg\",\"userType\":\"INHABITANT\"},\"content\":\"첫 댓글입니다.\",\"replyCount\":2,\"likeCount\":5,\"depth\":0,\"deleted\":false,\"isAuthor\":false,\"isLiked\":null,\"canEdit\":null,\"canDelete\":null,\"createdAt\":\"2025-01-01T10:10:00\"}],\"hasNext\":true,\"nextCursor\":\"eyJpZCI6NDU2fQ==\",\"size\":1,\"total\":50,\"isAuthorized\":false}"
+                                    )
+                            }
                     )
             ),
             @ApiResponse(

--- a/src/main/java/com/example/soso/community/freeboard/comment/domain/dto/FreeboardCommentCursorResponse.java
+++ b/src/main/java/com/example/soso/community/freeboard/comment/domain/dto/FreeboardCommentCursorResponse.java
@@ -1,5 +1,6 @@
 package com.example.soso.community.freeboard.comment.domain.dto;
 
+import com.example.soso.users.domain.entity.UserType;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -29,6 +30,9 @@ public class FreeboardCommentCursorResponse {
 
     @Schema(description = "현재 페이지 크기", example = "20", requiredMode = Schema.RequiredMode.REQUIRED)
     private int size;
+
+    @Schema(description = "총 댓글 수 (삭제된 댓글 포함)", example = "50", requiredMode = Schema.RequiredMode.REQUIRED)
+    private long total;
 
     @Schema(description = "요청한 사용자가 인증되었는지 여부 (액세스 토큰 제공 여부)", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
     private boolean isAuthorized;
@@ -60,6 +64,15 @@ public class FreeboardCommentCursorResponse {
         @Schema(description = "댓글 좋아요 수", example = "5", requiredMode = Schema.RequiredMode.REQUIRED)
         private int likeCount;
 
+        @Schema(description = "댓글 깊이 (0: 일반 댓글, 1: 대댓글)", example = "0", requiredMode = Schema.RequiredMode.REQUIRED)
+        private int depth;
+
+        @Schema(description = "삭제된 댓글 여부", example = "false", requiredMode = Schema.RequiredMode.REQUIRED)
+        private boolean deleted;
+
+        @Schema(description = "현재 사용자가 작성한 댓글인지", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+        private boolean isAuthor;
+
         @Schema(
             description = "현재 사용자의 댓글 좋아요 여부 (비인증 사용자인 경우 null)",
             example = "true",
@@ -69,14 +82,21 @@ public class FreeboardCommentCursorResponse {
         @JsonProperty("isLiked")
         private Boolean isLiked;
 
-        @Schema(description = "댓글 깊이 (0: 일반 댓글, 1: 대댓글)", example = "0", requiredMode = Schema.RequiredMode.REQUIRED)
-        private int depth;
+        @Schema(
+            description = "댓글 수정 가능 여부 (비인증 사용자인 경우 null)",
+            example = "true",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            nullable = true
+        )
+        private Boolean canEdit;
 
-        @Schema(description = "삭제된 댓글 여부", example = "false", requiredMode = Schema.RequiredMode.REQUIRED)
-        private boolean deleted;
-
-        @Schema(description = "현재 사용자가 작성한 댓글인지", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
-        private boolean isAuthor;
+        @Schema(
+            description = "댓글 삭제 가능 여부 (비인증 사용자인 경우 null)",
+            example = "true",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            nullable = true
+        )
+        private Boolean canDelete;
 
         @Schema(description = "작성 시간", example = "2024-12-25T10:30:00", requiredMode = Schema.RequiredMode.REQUIRED)
         private LocalDateTime createdAt;
@@ -88,6 +108,16 @@ public class FreeboardCommentCursorResponse {
         @JsonIgnore
         public Boolean isLiked() {
             return isLiked;
+        }
+
+        @JsonIgnore
+        public Boolean isCanEdit() {
+            return canEdit;
+        }
+
+        @JsonIgnore
+        public Boolean isCanDelete() {
+            return canDelete;
         }
     }
 
@@ -105,5 +135,8 @@ public class FreeboardCommentCursorResponse {
 
         @Schema(description = "작성자 프로필 이미지 URL", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private String profileImageUrl;
+
+        @Schema(description = "작성자 유형", example = "INHABITANT", requiredMode = Schema.RequiredMode.REQUIRED)
+        private UserType userType;
     }
 }

--- a/src/main/java/com/example/soso/community/freeboard/comment/domain/dto/FreeboardCommentCursorResponse.java
+++ b/src/main/java/com/example/soso/community/freeboard/comment/domain/dto/FreeboardCommentCursorResponse.java
@@ -1,5 +1,6 @@
 package com.example.soso.community.freeboard.comment.domain.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -29,6 +30,9 @@ public class FreeboardCommentCursorResponse {
     @Schema(description = "현재 페이지 크기", example = "20", requiredMode = Schema.RequiredMode.REQUIRED)
     private int size;
 
+    @Schema(description = "요청한 사용자가 인증되었는지 여부 (액세스 토큰 제공 여부)", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+    private boolean isAuthorized;
+
     @Schema(description = "댓글 요약 정보")
     @Getter
     @NoArgsConstructor
@@ -56,9 +60,14 @@ public class FreeboardCommentCursorResponse {
         @Schema(description = "댓글 좋아요 수", example = "5", requiredMode = Schema.RequiredMode.REQUIRED)
         private int likeCount;
 
-        @Schema(description = "현재 사용자의 댓글 좋아요 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+        @Schema(
+            description = "현재 사용자의 댓글 좋아요 여부 (비인증 사용자인 경우 null)",
+            example = "true",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            nullable = true
+        )
         @JsonProperty("isLiked")
-        private boolean isLiked;
+        private Boolean isLiked;
 
         @Schema(description = "댓글 깊이 (0: 일반 댓글, 1: 대댓글)", example = "0", requiredMode = Schema.RequiredMode.REQUIRED)
         private int depth;
@@ -74,6 +83,12 @@ public class FreeboardCommentCursorResponse {
 
         @Schema(description = "수정 시간", example = "2024-12-25T14:20:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private LocalDateTime updatedAt;
+
+        // Lombok @Getter가 생성하는 isLiked() 메서드를 Jackson이 "liked"로 직렬화하는 것을 방지
+        @JsonIgnore
+        public Boolean isLiked() {
+            return isLiked;
+        }
     }
 
     @Schema(description = "작성자 정보")

--- a/src/main/java/com/example/soso/community/freeboard/comment/service/FreeboardCommentServiceImpl.java
+++ b/src/main/java/com/example/soso/community/freeboard/comment/service/FreeboardCommentServiceImpl.java
@@ -110,6 +110,7 @@ public class FreeboardCommentServiceImpl
                 .hasNext(hasNext)
                 .nextCursor(nextCursor)
                 .size(summaries.size())
+                .isAuthorized(userId != null)
                 .build();
     }
 
@@ -146,9 +147,9 @@ public class FreeboardCommentServiceImpl
         // 댓글 좋아요 수 조회
         int likeCount = commentLikeRepository.countByComment_Id(comment.getId());
 
-        // 현재 사용자의 댓글 좋아요 여부 확인
-        boolean isLiked = userId != null &&
-                commentLikeRepository.existsByComment_IdAndUser_Id(comment.getId(), userId);
+        // 현재 사용자의 댓글 좋아요 여부 확인 (비인증 사용자는 null)
+        Boolean isLiked = userId != null ?
+                commentLikeRepository.existsByComment_IdAndUser_Id(comment.getId(), userId) : null;
 
         return FreeboardCommentCursorResponse.FreeboardCommentSummary.builder()
                 .commentId(comment.getId())

--- a/src/main/java/com/example/soso/community/freeboard/comment/service/FreeboardCommentServiceImpl.java
+++ b/src/main/java/com/example/soso/community/freeboard/comment/service/FreeboardCommentServiceImpl.java
@@ -105,11 +105,19 @@ public class FreeboardCommentServiceImpl
                 .map(comment -> createCommentSummary(comment, userId))
                 .toList();
 
+        // 첫 번째 댓글의 postId로 총 댓글 수 조회
+        long total = 0;
+        if (!comments.isEmpty()) {
+            Long postId = comments.get(0).getPost().getId();
+            total = commentRepository.countByPostId(postId);
+        }
+
         return FreeboardCommentCursorResponse.builder()
                 .comments(summaries)
                 .hasNext(hasNext)
                 .nextCursor(nextCursor)
                 .size(summaries.size())
+                .total(total)
                 .isAuthorized(userId != null)
                 .build();
     }
@@ -147,9 +155,19 @@ public class FreeboardCommentServiceImpl
         // 댓글 좋아요 수 조회
         int likeCount = commentLikeRepository.countByComment_Id(comment.getId());
 
-        // 현재 사용자의 댓글 좋아요 여부 확인 (비인증 사용자는 null)
-        Boolean isLiked = userId != null ?
+        // 인증 여부 확인
+        boolean isAuthorized = userId != null;
+
+        // 작성자 여부 확인
+        boolean isAuthor = userId != null && comment.getUser().getId().equals(userId);
+
+        // 인증된 사용자의 댓글 좋아요 여부 확인 (비인증 사용자는 null)
+        Boolean isLiked = isAuthorized ?
                 commentLikeRepository.existsByComment_IdAndUser_Id(comment.getId(), userId) : null;
+
+        // canEdit, canDelete 설정 (비인증 사용자는 null, 인증 사용자는 작성자 여부에 따라 boolean)
+        Boolean canEdit = isAuthorized ? isAuthor : null;
+        Boolean canDelete = isAuthorized ? isAuthor : null;
 
         return FreeboardCommentCursorResponse.FreeboardCommentSummary.builder()
                 .commentId(comment.getId())
@@ -159,14 +177,17 @@ public class FreeboardCommentServiceImpl
                         .userId(comment.getUser().getId())
                         .nickname(comment.getUser().getNickname())
                         .profileImageUrl(comment.getUser().getProfileImageUrl())
+                        .userType(comment.getUser().getUserType())
                         .build())
                 .content(comment.isDeleted() ? "삭제된 댓글입니다." : comment.getContent())
                 .replyCount(replyCount)
                 .likeCount(likeCount)
-                .isLiked(isLiked)
                 .depth(depth)
                 .deleted(comment.isDeleted())
-                .isAuthor(comment.getUser().getId().equals(userId))
+                .isAuthor(isAuthor)
+                .isLiked(isLiked)
+                .canEdit(canEdit)
+                .canDelete(canDelete)
                 .createdAt(comment.getCreatedDate())
                 .updatedAt(comment.getLastModifiedDate())
                 .build();

--- a/src/main/java/com/example/soso/community/freeboard/post/controller/FreeboardController.java
+++ b/src/main/java/com/example/soso/community/freeboard/post/controller/FreeboardController.java
@@ -126,7 +126,26 @@ public class FreeboardController {
 
     @Operation(
             summary = "자유게시판 글 상세 조회",
-            description = "게시글 ID를 통해 특정 게시글의 상세 정보를 조회합니다. 조회 시 조회수가 증가합니다."
+            description = """
+                    게시글 ID를 통해 특정 게시글의 상세 정보를 조회합니다.
+
+                    **특징:**
+                    - 조회 시 조회수 자동 증가
+                    - 인증/비인증 사용자 모두 조회 가능
+                    - 인증 여부에 따라 isLiked, canEdit, canDelete 값 변경
+
+                    **인증 사용자:**
+                    - isAuthorized: true
+                    - isLiked: boolean (좋아요 상태)
+                    - canEdit: boolean (수정 권한)
+                    - canDelete: boolean (삭제 권한)
+
+                    **비인증 사용자:**
+                    - isAuthorized: false
+                    - isLiked: null
+                    - canEdit: null
+                    - canDelete: null
+                    """
     )
     @ApiResponses({
             @ApiResponse(
@@ -136,12 +155,16 @@ public class FreeboardController {
                             schema = @Schema(implementation = FreeboardDetailResponse.class),
                             examples = {
                                     @ExampleObject(
-                                            name = "인증 사용자",
-                                            value = "{\"postId\":123,\"author\":{\"userId\":\"author123\",\"nickname\":\"작성자\",\"profileImageUrl\":\"https://cdn.example.com/profile.jpg\",\"userType\":\"INHABITANT\",\"address\":\"서울시 강남구\"},\"category\":\"restaurant\",\"title\":\"맛있는 라면집 추천해요!\",\"content\":\"인증 사용자가 작성한 게시글입니다.\",\"images\":[{\"imageId\":1,\"imageUrl\":\"https://cdn.example.com/image1.jpg\",\"sequence\":0}],\"likeCount\":10,\"commentCount\":3,\"viewCount\":120,\"isLiked\":true,\"createdAt\":\"2025-01-01T10:00:00\",\"updatedAt\":\"2025-01-02T09:30:00\",\"isAuthor\":true,\"canEdit\":true,\"canDelete\":true}"
+                                            name = "인증 사용자 (본인 작성)",
+                                            value = "{\"postId\":123,\"author\":{\"userId\":\"author123\",\"nickname\":\"작성자\",\"profileImageUrl\":\"https://cdn.example.com/profile.jpg\",\"userType\":\"INHABITANT\",\"address\":\"서울시 강남구\"},\"category\":\"restaurant\",\"title\":\"맛있는 라면집 추천해요!\",\"content\":\"인증 사용자가 작성한 게시글입니다.\",\"images\":[{\"imageId\":1,\"imageUrl\":\"https://cdn.example.com/image1.jpg\",\"sequence\":0}],\"likeCount\":10,\"commentCount\":3,\"viewCount\":120,\"createdAt\":\"2025-01-01T10:00:00\",\"updatedAt\":\"2025-01-02T09:30:00\",\"isAuthorized\":true,\"isAuthor\":true,\"isLiked\":false,\"canEdit\":true,\"canDelete\":true}"
+                                    ),
+                                    @ExampleObject(
+                                            name = "인증 사용자 (다른 사람 글, 좋아요 누름)",
+                                            value = "{\"postId\":456,\"author\":{\"userId\":\"other-user\",\"nickname\":\"다른사용자\",\"profileImageUrl\":\"https://cdn.example.com/profile2.jpg\",\"userType\":\"FOUNDER\",\"address\":\"서울시 서초구\"},\"category\":\"startup\",\"title\":\"창업 성공 스토리\",\"content\":\"3개월만에 매출 10배 증가!\",\"images\":[],\"likeCount\":50,\"commentCount\":15,\"viewCount\":500,\"createdAt\":\"2025-01-05T14:20:00\",\"updatedAt\":\"2025-01-06T10:15:00\",\"isAuthorized\":true,\"isAuthor\":false,\"isLiked\":true,\"canEdit\":false,\"canDelete\":false}"
                                     ),
                                     @ExampleObject(
                                             name = "비인증 사용자",
-                                            value = "{\"postId\":123,\"author\":{\"userId\":\"author123\",\"nickname\":\"작성자\",\"profileImageUrl\":\"https://cdn.example.com/profile.jpg\",\"userType\":\"INHABITANT\",\"address\":\"서울시 강남구\"},\"category\":\"restaurant\",\"title\":\"맛있는 라면집 추천해요!\",\"content\":\"비인증 사용자가 조회한 게시글입니다.\",\"images\":[],\"likeCount\":10,\"commentCount\":3,\"viewCount\":120,\"isLiked\":false,\"createdAt\":\"2025-01-01T10:00:00\",\"updatedAt\":\"2025-01-02T09:30:00\",\"isAuthor\":false,\"canEdit\":false,\"canDelete\":false}"
+                                            value = "{\"postId\":123,\"author\":{\"userId\":\"author123\",\"nickname\":\"작성자\",\"profileImageUrl\":\"https://cdn.example.com/profile.jpg\",\"userType\":\"INHABITANT\",\"address\":\"서울시 강남구\"},\"category\":\"restaurant\",\"title\":\"맛있는 라면집 추천해요!\",\"content\":\"비인증 사용자가 조회한 게시글입니다.\",\"images\":[],\"likeCount\":10,\"commentCount\":3,\"viewCount\":120,\"createdAt\":\"2025-01-01T10:00:00\",\"isAuthorized\":false,\"isAuthor\":false,\"isLiked\":null,\"canEdit\":null,\"canDelete\":null}"
                                     )
                             }
                     )

--- a/src/main/java/com/example/soso/community/freeboard/post/domain/dto/FreeboardCursorResponse.java
+++ b/src/main/java/com/example/soso/community/freeboard/post/domain/dto/FreeboardCursorResponse.java
@@ -2,6 +2,8 @@ package com.example.soso.community.freeboard.post.domain.dto;
 
 import com.example.soso.community.common.post.domain.entity.Category;
 import com.example.soso.users.domain.entity.UserType;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -32,6 +34,9 @@ public class FreeboardCursorResponse {
 
     @Schema(description = "총 게시글 수", example = "150", requiredMode = Schema.RequiredMode.REQUIRED)
     private long totalCount;
+
+    @Schema(description = "요청한 사용자가 인증되었는지 여부 (액세스 토큰 제공 여부)", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+    private boolean isAuthorized;
 
     @Schema(description = "게시글 요약 정보")
     @Getter
@@ -69,14 +74,26 @@ public class FreeboardCursorResponse {
         @Schema(description = "조회 수", example = "102", requiredMode = Schema.RequiredMode.REQUIRED)
         private int viewCount;
 
-        @Schema(description = "현재 사용자의 좋아요 여부", example = "false", requiredMode = Schema.RequiredMode.REQUIRED)
-        private boolean isLiked;
+        @Schema(
+            description = "현재 사용자의 좋아요 여부 (비인증 사용자인 경우 null)",
+            example = "false",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            nullable = true
+        )
+        @JsonProperty("isLiked")
+        private Boolean isLiked;
 
         @Schema(description = "작성 시간", example = "2024-12-25T10:30:00", requiredMode = Schema.RequiredMode.REQUIRED)
         private LocalDateTime createdAt;
 
         @Schema(description = "수정 시간", example = "2024-12-25T14:20:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
         private LocalDateTime updatedAt;
+
+        // Lombok @Getter가 생성하는 isLiked() 메서드를 Jackson이 "liked"로 직렬화하는 것을 방지
+        @JsonIgnore
+        public Boolean isLiked() {
+            return isLiked;
+        }
     }
 
     @Schema(description = "작성자 정보")

--- a/src/main/java/com/example/soso/community/freeboard/post/domain/dto/FreeboardDetailResponse.java
+++ b/src/main/java/com/example/soso/community/freeboard/post/domain/dto/FreeboardDetailResponse.java
@@ -2,6 +2,7 @@ package com.example.soso.community.freeboard.post.domain.dto;
 
 import com.example.soso.community.common.post.domain.entity.Category;
 import com.example.soso.users.domain.entity.UserType;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
@@ -46,24 +47,58 @@ public class FreeboardDetailResponse {
     @Schema(description = "조회 수", example = "102", requiredMode = Schema.RequiredMode.REQUIRED)
     private int viewCount;
 
-    @Schema(description = "현재 사용자의 좋아요 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
-    @JsonProperty("isLiked")
-    private boolean isLiked;
-
     @Schema(description = "작성 시간", example = "2024-12-25T10:30:00", requiredMode = Schema.RequiredMode.REQUIRED)
     private LocalDateTime createdAt;
 
     @Schema(description = "수정 시간", example = "2024-12-25T14:20:00", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
     private LocalDateTime updatedAt;
 
+    @Schema(description = "요청한 사용자가 인증되었는지 여부 (액세스 토큰 제공 여부)", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+    private boolean isAuthorized;
+
     @Schema(description = "작성자 여부 (현재 사용자가 작성자인지)", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
     private boolean isAuthor;
 
-    @Schema(description = "편집 가능 여부 (인증된 사용자이고 작성자인 경우)", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
-    private boolean canEdit;
+    @Schema(
+        description = "현재 사용자의 좋아요 여부 (비인증 사용자인 경우 null)",
+        example = "true",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+        nullable = true
+    )
+    @JsonProperty("isLiked")
+    private Boolean isLiked;
 
-    @Schema(description = "삭제 가능 여부 (인증된 사용자이고 작성자인 경우)", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
-    private boolean canDelete;
+    @Schema(
+        description = "편집 가능 여부 (비인증 사용자인 경우 null)",
+        example = "true",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+        nullable = true
+    )
+    private Boolean canEdit;
+
+    @Schema(
+        description = "삭제 가능 여부 (비인증 사용자인 경우 null)",
+        example = "true",
+        requiredMode = Schema.RequiredMode.REQUIRED,
+        nullable = true
+    )
+    private Boolean canDelete;
+
+    // Lombok @Getter가 생성하는 isLiked() 메서드를 Jackson이 "liked"로 직렬화하는 것을 방지
+    @JsonIgnore
+    public Boolean isLiked() {
+        return isLiked;
+    }
+
+    @JsonIgnore
+    public Boolean isCanEdit() {
+        return canEdit;
+    }
+
+    @JsonIgnore
+    public Boolean isCanDelete() {
+        return canDelete;
+    }
 
     @Schema(description = "이미지 정보")
     @Getter

--- a/src/main/java/com/example/soso/community/freeboard/post/service/FreeboardServiceImpl.java
+++ b/src/main/java/com/example/soso/community/freeboard/post/service/FreeboardServiceImpl.java
@@ -104,8 +104,8 @@ public class FreeboardServiceImpl implements FreeboardService {
 
         post.increaseViewCount();
 
-        // 좋아요 여부 확인 (인증된 사용자인 경우만)
-        boolean isLiked = userId != null && postLikeRepository.existsByPost_IdAndUser_Id(postId, userId);
+        // 인증 여부 확인
+        boolean isAuthorized = userId != null;
 
         // 이미지 정보 목록 추출
         List<FreeboardDetailResponse.ImageInfo> images = post.getImages().stream()
@@ -121,7 +121,7 @@ public class FreeboardServiceImpl implements FreeboardService {
         boolean isAuthor = userId != null && post.getUser().getId().equals(userId);
 
         // 응답 DTO 생성
-        return FreeboardDetailResponse.builder()
+        FreeboardDetailResponse.FreeboardDetailResponseBuilder builder = FreeboardDetailResponse.builder()
                 .postId(post.getId())
                 .author(FreeboardDetailResponse.PostDetailAuthorInfo.builder()
                         .userId(post.getUser().getId())
@@ -137,13 +137,25 @@ public class FreeboardServiceImpl implements FreeboardService {
                 .likeCount(post.getLikeCount())
                 .commentCount(post.getCommentCount())
                 .viewCount(post.getViewCount())
-                .isLiked(isLiked)
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
-                .isAuthor(isAuthor)
-                .canEdit(userId != null && isAuthor) // 인증된 사용자이고 작성자인 경우만 편집 가능
-                .canDelete(userId != null && isAuthor) // 인증된 사용자이고 작성자인 경우만 삭제 가능
-                .build();
+                .isAuthorized(isAuthorized)
+                .isAuthor(isAuthor);
+
+        // 인증된 사용자인 경우에만 isLiked, canEdit, canDelete 설정
+        if (isAuthorized) {
+            boolean isLiked = postLikeRepository.existsByPost_IdAndUser_Id(postId, userId);
+            builder.isLiked(isLiked)
+                   .canEdit(isAuthor)
+                   .canDelete(isAuthor);
+        } else {
+            // 비인증 사용자는 null
+            builder.isLiked(null)
+                   .canEdit(null)
+                   .canDelete(null);
+        }
+
+        return builder.build();
     }
 
     @Override
@@ -192,6 +204,7 @@ public class FreeboardServiceImpl implements FreeboardService {
                 .nextCursor(nextCursor)
                 .size(summaries.size())
                 .totalCount(totalCount)
+                .isAuthorized(userId != null)
                 .build();
     }
 

--- a/src/test/java/com/example/soso/community/freeboard/integration/LikeSystemIntegrationTest.java
+++ b/src/test/java/com/example/soso/community/freeboard/integration/LikeSystemIntegrationTest.java
@@ -220,9 +220,12 @@ class LikeSystemIntegrationTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.isAuthorized").value(true))
+                .andExpect(jsonPath("$.total").isNumber())
                 .andExpect(jsonPath("$.comments").isArray())
                 .andExpect(jsonPath("$.comments[0].likeCount").value(3))
-                .andExpect(jsonPath("$.comments[0].isLiked").value(true)); // liker1이 좋아요 눌렀으므로
+                .andExpect(jsonPath("$.comments[0].isLiked").value(true))
+                .andExpect(jsonPath("$.comments[0].canEdit").value(false))
+                .andExpect(jsonPath("$.comments[0].canDelete").value(false)); // liker1은 작성자가 아님
 
         System.out.println("✅ 댓글 좋아요 상태 확인 완료!");
 
@@ -277,8 +280,11 @@ class LikeSystemIntegrationTest {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.isAuthorized").value(true))
+                .andExpect(jsonPath("$.total").isNumber())
                 .andExpect(jsonPath("$.comments[0].likeCount").value(2))
-                .andExpect(jsonPath("$.comments[0].isLiked").value(false)); // commenter는 댓글에 좋아요 안 눌렀음
+                .andExpect(jsonPath("$.comments[0].isLiked").value(false)) // commenter는 댓글에 좋아요 안 눌렀음
+                .andExpect(jsonPath("$.comments[0].canEdit").value(true)) // 본인 댓글이므로 수정 가능
+                .andExpect(jsonPath("$.comments[0].canDelete").value(true)); // 본인 댓글이므로 삭제 가능
 
         System.out.println("✅ 최종 상태: 게시글 좋아요 1개, 댓글 좋아요 2개");
         System.out.println("\n🎉 === 좋아요 생태계 시나리오 완료 ===");

--- a/src/test/java/com/example/soso/community/freeboard/integration/LikeSystemIntegrationTest.java
+++ b/src/test/java/com/example/soso/community/freeboard/integration/LikeSystemIntegrationTest.java
@@ -135,6 +135,7 @@ class LikeSystemIntegrationTest {
                         .header("Authorization", liker1.getAuthHeader()))
                 .andDo(print())
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isAuthorized").value(true))
                 .andExpect(jsonPath("$.likeCount").value(1))
                 .andExpect(jsonPath("$.isLiked").value(true))
                 .andReturn();
@@ -156,6 +157,7 @@ class LikeSystemIntegrationTest {
                         .header("Authorization", postAuthor.getAuthHeader()))
                 .andDo(print())
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isAuthorized").value(true))
                 .andExpect(jsonPath("$.likeCount").value(2))
                 .andExpect(jsonPath("$.isLiked").value(false)) // 작성자는 아직 좋아요 안 눌렀음
                 .andReturn();
@@ -217,6 +219,7 @@ class LikeSystemIntegrationTest {
                         .param("size", "20"))
                 .andDo(print())
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isAuthorized").value(true))
                 .andExpect(jsonPath("$.comments").isArray())
                 .andExpect(jsonPath("$.comments[0].likeCount").value(3))
                 .andExpect(jsonPath("$.comments[0].isLiked").value(true)); // liker1이 좋아요 눌렀으므로
@@ -240,6 +243,7 @@ class LikeSystemIntegrationTest {
                         .header("Authorization", liker1.getAuthHeader()))
                 .andDo(print())
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isAuthorized").value(true))
                 .andExpect(jsonPath("$.likeCount").value(1)) // 2개에서 1개로 감소
                 .andExpect(jsonPath("$.isLiked").value(false)); // 취소했으므로 false
 
@@ -272,6 +276,7 @@ class LikeSystemIntegrationTest {
                         .header("Authorization", commenter.getAuthHeader()))
                 .andDo(print())
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isAuthorized").value(true))
                 .andExpect(jsonPath("$.comments[0].likeCount").value(2))
                 .andExpect(jsonPath("$.comments[0].isLiked").value(false)); // commenter는 댓글에 좋아요 안 눌렀음
 
@@ -421,6 +426,7 @@ class LikeSystemIntegrationTest {
                         .header("Authorization", users[0].getAuthHeader()))
                 .andDo(print())
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isAuthorized").value(true))
                 .andExpect(jsonPath("$.likeCount").value(5))
                 .andExpect(jsonPath("$.isLiked").value(true));
 


### PR DESCRIPTION
# 🔧 게시글/댓글 응답 개선: 인증 여부 명시 및 권한 필드 추가

## 📝 개요

게시글 상세 조회 및 댓글 커서 조회 API의 응답 구조를 개선하여, 프론트엔드에서 인증/비인증 상태를 명확히 구분하고 사용자 권한을 쉽게 판단할 수 있도록 개선했습니다.

## 🎯 작업 목표

### 기존 문제점
1. **인증 여부 불명확**: 클라이언트가 `isLiked: false`와 비인증 상태를 구분할 수 없음
2. **권한 판단 로직 중복**: 프론트에서 `isAuthor`를 기반으로 수정/삭제 가능 여부를 매번 계산
3. **Jackson 중복 직렬화**: `isLiked` 필드가 `liked`로도 중복 직렬화됨
4. **댓글 총 개수 부재**: 페이징된 댓글의 전체 개수를 알 수 없음
5. **작성자 유형 누락**: 댓글 작성자의 `userType` 정보 부재

### 해결 방안
- `isAuthorized` 필드 추가로 인증 여부 명시
- `canEdit`, `canDelete` 필드 추가로 권한 정보 제공
- `isLiked`, `canEdit`, `canDelete`를 nullable로 변경 (비인증 시 `null`)
- Jackson `@JsonIgnore`로 중복 필드 제거
- 댓글 응답에 `total` 필드 추가
- 댓글 작성자에 `userType` 필드 추가

---

## 🔄 변경 사항

### 1️⃣ 게시글 상세 조회 (`GET /community/freeboard/{freeboardId}`)

#### ✅ 추가된 필드
- **`isAuthorized`** (`boolean`, required): 요청 사용자의 인증 여부
- **`canEdit`** (`boolean | null`, required): 수정 권한 (비인증: `null`)
- **`canDelete`** (`boolean | null`, required): 삭제 권한 (비인증: `null`)

#### ✅ 변경된 필드
- **`isLiked`**: `boolean` → `boolean | null` (비인증: `null`)

#### ✅ 제거된 필드
- **`liked`**: Jackson 중복 직렬화로 인한 불필요한 필드 제거

#### 📊 응답 예시

**인증 사용자 (본인 작성)**
```json
{
  "postId": 123,
  "isAuthorized": true,
  "isAuthor": true,
  "isLiked": false,
  "canEdit": true,
  "canDelete": true,
  ...
}
```

**비인증 사용자**
```json
{
  "postId": 123,
  "isAuthorized": false,
  "isAuthor": false,
  "isLiked": null,
  "canEdit": null,
  "canDelete": null,
  ...
}
```

---

### 2️⃣ 댓글 커서 조회 (`GET /community/freeboard/{freeboardId}/comments`)

#### ✅ 응답 최상위에 추가된 필드
- **`total`** (`number`, required): 총 댓글 수 (삭제된 댓글 포함)
- **`isAuthorized`** (`boolean`, required): 요청 사용자의 인증 여부

#### ✅ 각 댓글에 추가된 필드
- **`canEdit`** (`boolean | null`, required): 수정 권한 (비인증: `null`)
- **`canDelete`** (`boolean | null`, required): 삭제 권한 (비인증: `null`)

#### ✅ 댓글 작성자 정보에 추가된 필드
- **`userType`** (`UserType`, required): 작성자 유형 (INHABITANT, FOUNDER)

#### ✅ 변경된 필드
- **`isLiked`**: `boolean` → `boolean | null` (비인증: `null`)

#### ✅ 제거된 필드
- **`liked`**: Jackson 중복 직렬화로 인한 불필요한 필드 제거

#### 📊 응답 예시

**인증 사용자 (본인 댓글)**
```json
{
  "comments": [
    {
      "commentId": 456,
      "author": {
        "userId": "user123",
        "nickname": "댓글러",
        "userType": "INHABITANT"
      },
      "isAuthor": true,
      "isLiked": false,
      "canEdit": true,
      "canDelete": true,
      ...
    }
  ],
  "total": 50,
  "isAuthorized": true,
  ...
}
```

**비인증 사용자**
```json
{
  "comments": [
    {
      "commentId": 456,
      "author": {
        "userId": "user123",
        "nickname": "댓글러",
        "userType": "INHABITANT"
      },
      "isAuthor": false,
      "isLiked": null,
      "canEdit": null,
      "canDelete": null,
      ...
    }
  ],
  "total": 50,
  "isAuthorized": false,
  ...
}
```

---

## 💻 TypeScript 타입 변경

### 게시글 상세 조회
```typescript
export interface FreeboardDetailResponse {
  postId: number;
  isAuthorized: boolean;      // ⭐ NEW
  isAuthor: boolean;

  // Required + Nullable (비인증 시 null)
  isLiked: boolean | null;    // ⭐ CHANGED
  canEdit: boolean | null;    // ⭐ NEW
  canDelete: boolean | null;  // ⭐ NEW

  // ... 기타 필드
}
```

### 댓글 커서 조회
```typescript
export interface FreeboardCommentCursorResponse {
  comments: FreeboardCommentSummary[];
  total: number;              // ⭐ NEW
  isAuthorized: boolean;      // ⭐ NEW
  hasNext: boolean;
  size: number;
  nextCursor?: string;
}

export interface FreeboardCommentSummary {
  commentId: number;
  author: CommentAuthorInfo;
  isAuthor: boolean;

  // Required + Nullable (비인증 시 null)
  isLiked: boolean | null;   // ⭐ CHANGED
  canEdit: boolean | null;   // ⭐ NEW
  canDelete: boolean | null; // ⭐ NEW

  // ... 기타 필드
}

export interface CommentAuthorInfo {
  userId: string;
  nickname: string;
  userType: UserType;        // ⭐ NEW
  profileImageUrl?: string;
}
```

---

## 🔧 기술적 세부사항

### 1. Jackson 중복 직렬화 방지

**문제**: Lombok `@Getter`가 `boolean isLiked` 필드에 대해 `isLiked()` 메서드를 생성하고, Jackson이 이를 `"liked"`로도 직렬화

**해결**:
```java
@JsonProperty("isLiked")
private Boolean isLiked;

@JsonIgnore
public Boolean isLiked() {
    return isLiked;
}
```

### 2. OpenAPI 스펙 정확성

- **Required + Nullable**: `requiredMode = REQUIRED, nullable = true`
- 비인증 시 항상 `null` 반환이므로 `NOT_REQUIRED`가 아닌 `REQUIRED`
- Orval 타입 생성 시 `isLiked: boolean | null` (not `isLiked?: boolean | null`)

### 3. 총 댓글 수 계산

```java
long total = 0;
if (!comments.isEmpty()) {
    Long postId = comments.get(0).getPost().getId();
    total = commentRepository.countByPostId(postId);
}
```

### 4. 권한 로직

```java
boolean isAuthorized = userId != null;
boolean isAuthor = userId != null && comment.getUser().getId().equals(userId);

Boolean canEdit = isAuthorized ? isAuthor : null;
Boolean canDelete = isAuthorized ? isAuthor : null;
```

---

## 🧪 테스트

### 수정된 테스트 파일
- `LikeSystemIntegrationTest.java`: 모든 테스트 케이스에 `isAuthorized`, `total`, `canEdit`, `canDelete` 검증 추가

### 주요 검증 항목
1. ✅ 인증 사용자: `isAuthorized: true`, nullable 필드에 `boolean` 값
2. ✅ 비인증 사용자: `isAuthorized: false`, nullable 필드에 `null` 값
3. ✅ 본인 작성: `canEdit: true`, `canDelete: true`
4. ✅ 다른 사람 작성: `canEdit: false`, `canDelete: false`
5. ✅ 댓글 총 개수: `total` 필드 정상 반환

---

## 📋 변경된 파일 목록

### DTO
- `FreeboardDetailResponse.java`: 필드 추가 및 Jackson 처리
- `FreeboardCursorResponse.java`: `isAuthorized` 추가
- `FreeboardCommentCursorResponse.java`: `total`, 필드 추가 및 Jackson 처리
- `PostSummaryResponse.java`: `likeByPost` nullable 처리

### Service
- `FreeboardServiceImpl.java`: 조건부 null 처리 로직
- `FreeboardCommentServiceImpl.java`: `total` 계산 및 권한 로직
- `PostRepositoryImpl.java`: 비인증 사용자 쿼리 null 처리

### Controller
- `FreeboardController.java`: Swagger 문서 업데이트
- `FreeboardCommentController.java`: Swagger 문서 업데이트

### Test
- `LikeSystemIntegrationTest.java`: 검증 항목 추가

---

## 🎨 프론트엔드 사용 예시

### Before (기존)
```typescript
// ❌ 인증 여부를 알 수 없음
if (post.isLiked === false) {
  // 비로그인? 로그인했지만 좋아요 안 누름?
}

// ❌ 권한 판단 로직 중복
if (post.isAuthor) {
  showEditButton();
  showDeleteButton();
}
```

### After (개선)
```typescript
// ✅ 인증 여부 명확
if (post.isAuthorized) {
  if (post.isLiked) {
    showFilledHeart();
  } else {
    showEmptyHeart();
  }

  // ✅ 서버에서 제공하는 권한 정보 사용
  if (post.canEdit) showEditButton();
  if (post.canDelete) showDeleteButton();
} else {
  // 비인증 사용자: isLiked === null
  showLoginPrompt();
}

// ✅ 총 댓글 수 표시
console.log(`총 댓글: ${commentsResponse.total}개`);
```

---

## 🚀 마이그레이션 가이드

### 프론트엔드 변경 필요 사항

1. **타입 업데이트**: Orval 재생성
   ```bash
   npm run generate:api
   ```

2. **필드명 변경**: `liked` → `isLiked` (중복 제거)
   - 기존 코드에서 `response.liked` 사용 시 `response.isLiked`로 변경

3. **null 체크 추가**: `isLiked`, `canEdit`, `canDelete`
   ```typescript
   // Before
   if (post.isLiked) { ... }

   // After
   if (post.isLiked === true) { ... }
   // or
   if (post.isAuthorized && post.isLiked) { ... }
   ```

4. **권한 판단 로직 단순화**: `isAuthor` 기반 → `canEdit`/`canDelete` 사용
   ```typescript
   // Before
   if (post.isAuthor) {
     showEditButton();
   }

   // After
   if (post.canEdit) {
     showEditButton();
   }
   ```

---

## ✅ Breaking Changes

### 🔴 주의: API 응답 변경

1. **필드 타입 변경**: `isLiked`, `canEdit`, `canDelete`가 nullable
   - 비인증 요청 시 `null` 반환
   - 기존 `boolean` 타입에서 `boolean | null`로 변경

2. **필드 추가**: 응답에 새로운 필드 추가
   - `isAuthorized`: 모든 응답
   - `canEdit`, `canDelete`: 게시글/댓글
   - `total`: 댓글 목록
   - `userType`: 댓글 작성자 정보

3. **중복 필드 제거**: `liked` 필드 제거
   - Jackson 중복 직렬화 방지

---

## 📸 Swagger 문서 스크린샷

### 게시글 상세 조회
- ✅ 3가지 시나리오 예시 제공
  - 인증 사용자 (본인 작성)
  - 인증 사용자 (다른 사람 글, 좋아요 누름)
  - 비인증 사용자

### 댓글 커서 조회
- ✅ 2가지 시나리오 예시 제공
  - 인증 사용자 (본인 댓글 포함)
  - 비인증 사용자

---

## 📚 관련 이슈

- 게시글/댓글 API 응답 개선
- 프론트엔드 인증 상태 처리 개선
- OpenAPI/Orval 타입 정확성 향상

---


## 📝 체크리스트

- [x] 코드 작성 완료
- [x] 테스트 코드 작성 및 통과
- [x] Swagger 문서 업데이트
- [x] PR 설명 작성
- [x] Breaking Changes 문서화
- [x] 마이그레이션 가이드 작성
